### PR TITLE
feat(dashboard): add budget visibility preferences

### DIFF
--- a/modules/ai-assistant/receipt-ocr-job-processor.service.test.ts
+++ b/modules/ai-assistant/receipt-ocr-job-processor.service.test.ts
@@ -244,4 +244,297 @@ describe('receipt-ocr-job-processor.service', () => {
 		);
 		expect(result.createdTransaction.category).toBe('Food & Dining');
 	});
+
+	it('falls back to noon local time when dateTime is missing', async () => {
+		mockedAnalyzeReceiptImageForUser.mockResolvedValue({
+			date: '2026-04-06',
+			dateTime: '',
+			description: 'Lunch',
+			amount: 12,
+			category: 'Other',
+			type: 'expense',
+			currency: 'USD',
+			referenceId: undefined,
+			isDuplicate: false,
+			beloWithdrawMatch: null,
+			rawText: 'Lunch',
+			textLines: ['Lunch'],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
+
+		await processReceiptOcrJob({
+			id: 'job-4',
+			userId: 2,
+			status: 'processing',
+			reviewStatus: 'pending_review',
+			reviewedAt: null,
+			timeZone: 'America/Argentina/Buenos_Aires',
+			createdAt: '2026-04-06T10:00:00.000Z',
+			updatedAt: '2026-04-06T10:00:00.000Z',
+			attempts: 1,
+			maxAttempts: 3,
+			image: {
+				publicUrl: 'https://example.com/receipt-4.jpg',
+				filePath: '/tmp/receipt-4.jpg',
+				fileName: 'receipt-4.jpg',
+				size: 111,
+			},
+		});
+
+		expect(mockedBaseTransactions.safeCreateTransaction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				date: '2026-04-06T15:00:00.000Z',
+			})
+		);
+	});
+
+	it('keeps dateTime unchanged when no timezone is provided and normalizes duplicate credit previews', async () => {
+		mockedAnalyzeReceiptImageForUser.mockResolvedValue({
+			date: '2026-04-07',
+			dateTime: '2026-04-07T08:30:00',
+			description: 'Refund',
+			amount: 15,
+			category: 'Other',
+			type: 'income',
+			currency: 'USD',
+			referenceId: 'dup-1',
+			isDuplicate: true,
+			beloWithdrawMatch: null,
+			rawText: 'Refund',
+			textLines: ['Refund'],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
+		mockedBaseTransactions.safeCreateTransaction.mockResolvedValue({
+			transaction: {
+				id: 52,
+				date: new Date('2026-04-07T08:30:00.000Z'),
+				description: null,
+				amount: 15,
+				currency: 'USD',
+				type: 'credit',
+				referenceId: null,
+				category: null,
+			},
+			isDuplicate: true,
+		} as never);
+
+		const result = await processReceiptOcrJob({
+			id: 'job-5',
+			userId: 3,
+			status: 'processing',
+			reviewStatus: 'pending_review',
+			reviewedAt: null,
+			timeZone: null,
+			createdAt: '2026-04-07T08:00:00.000Z',
+			updatedAt: '2026-04-07T08:00:00.000Z',
+			attempts: 1,
+			maxAttempts: 3,
+			image: {
+				publicUrl: 'https://example.com/receipt-5.jpg',
+				filePath: '/tmp/receipt-5.jpg',
+				fileName: 'receipt-5.jpg',
+				size: 111,
+			},
+		});
+
+		expect(mockedBaseTransactions.safeCreateTransaction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				date: '2026-04-07T08:30:00',
+				type: 'credit',
+			})
+		);
+		expect(result.createdTransaction).toEqual({
+			id: 52,
+			date: '2026-04-07T08:30:00.000Z',
+			description: 'Scanned receipt',
+			amount: 15,
+			currency: 'USD',
+			category: 'Other',
+			type: 'income',
+			referenceId: null,
+			isDuplicate: true,
+		});
+	});
+
+	it('prefers the longest keyword match when multiple categories match', async () => {
+		mockedPrisma.category.findMany.mockResolvedValue([
+			{
+				id: 31,
+				name: 'Shopping',
+				categoryKeyword: [{ keyword: { name: 'villa' } }],
+			},
+			{
+				id: 32,
+				name: 'Food & Dining',
+				categoryKeyword: [{ keyword: { name: 'villa ortuzar' } }],
+			},
+		]);
+		mockedAnalyzeReceiptImageForUser.mockResolvedValue({
+			date: '2026-04-08',
+			dateTime: '2026-04-08T19:00:00',
+			description: 'Dinner in Villa Ortuzar',
+			amount: 25,
+			category: 'Other',
+			type: 'expense',
+			currency: 'USD',
+			referenceId: undefined,
+			isDuplicate: false,
+			beloWithdrawMatch: null,
+			rawText: 'Dinner in Villa Ortuzar',
+			textLines: ['Dinner in Villa Ortuzar'],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
+
+		await processReceiptOcrJob({
+			id: 'job-6',
+			userId: 4,
+			status: 'processing',
+			reviewStatus: 'pending_review',
+			reviewedAt: null,
+			timeZone: 'America/Argentina/Buenos_Aires',
+			createdAt: '2026-04-08T18:00:00.000Z',
+			updatedAt: '2026-04-08T18:00:00.000Z',
+			attempts: 1,
+			maxAttempts: 3,
+			image: {
+				publicUrl: 'https://example.com/receipt-6.jpg',
+				filePath: '/tmp/receipt-6.jpg',
+				fileName: 'receipt-6.jpg',
+				size: 222,
+			},
+		});
+
+		expect(mockedBaseTransactions.safeCreateTransaction).toHaveBeenCalledWith(
+			expect.objectContaining({ categoryId: 32 })
+		);
+	});
+
+	it('throws when the receipt description is empty', async () => {
+		mockedAnalyzeReceiptImageForUser.mockResolvedValue({
+			date: '2026-04-09',
+			dateTime: '2026-04-09T10:00:00',
+			description: '   ',
+			amount: 10,
+			category: 'Other',
+			type: 'expense',
+			currency: 'USD',
+			referenceId: undefined,
+			isDuplicate: false,
+			beloWithdrawMatch: null,
+			rawText: '',
+			textLines: [],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
+
+		await expect(
+			processReceiptOcrJob({
+				id: 'job-7',
+				userId: 5,
+				status: 'processing',
+				reviewStatus: 'pending_review',
+				reviewedAt: null,
+				timeZone: null,
+				createdAt: '2026-04-09T09:00:00.000Z',
+				updatedAt: '2026-04-09T09:00:00.000Z',
+				attempts: 1,
+				maxAttempts: 3,
+				image: {
+					publicUrl: 'https://example.com/receipt-7.jpg',
+					filePath: '/tmp/receipt-7.jpg',
+					fileName: 'receipt-7.jpg',
+					size: 50,
+				},
+			})
+		).rejects.toThrow('Receipt description could not be extracted automatically');
+	});
+
+	it('throws when the receipt amount is invalid', async () => {
+		mockedAnalyzeReceiptImageForUser.mockResolvedValue({
+			date: '2026-04-09',
+			dateTime: '2026-04-09T10:00:00',
+			description: 'Coffee',
+			amount: 0,
+			category: 'Other',
+			type: 'expense',
+			currency: 'USD',
+			referenceId: undefined,
+			isDuplicate: false,
+			beloWithdrawMatch: null,
+			rawText: '',
+			textLines: [],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
+
+		await expect(
+			processReceiptOcrJob({
+				id: 'job-8',
+				userId: 5,
+				status: 'processing',
+				reviewStatus: 'pending_review',
+				reviewedAt: null,
+				timeZone: null,
+				createdAt: '2026-04-09T09:00:00.000Z',
+				updatedAt: '2026-04-09T09:00:00.000Z',
+				attempts: 1,
+				maxAttempts: 3,
+				image: {
+					publicUrl: 'https://example.com/receipt-8.jpg',
+					filePath: '/tmp/receipt-8.jpg',
+					fileName: 'receipt-8.jpg',
+					size: 50,
+				},
+			})
+		).rejects.toThrow('Receipt amount could not be extracted automatically');
+	});
+
+	it('throws when the receipt transaction type cannot be normalized', async () => {
+		mockedAnalyzeReceiptImageForUser.mockResolvedValue({
+			date: '2026-04-09',
+			dateTime: '2026-04-09T10:00:00',
+			description: 'Coffee',
+			amount: 5,
+			category: 'Other',
+			type: 'mystery' as never,
+			currency: 'USD',
+			referenceId: undefined,
+			isDuplicate: false,
+			beloWithdrawMatch: null,
+			rawText: '',
+			textLines: [],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
+
+		await expect(
+			processReceiptOcrJob({
+				id: 'job-9',
+				userId: 5,
+				status: 'processing',
+				reviewStatus: 'pending_review',
+				reviewedAt: null,
+				timeZone: null,
+				createdAt: '2026-04-09T09:00:00.000Z',
+				updatedAt: '2026-04-09T09:00:00.000Z',
+				attempts: 1,
+				maxAttempts: 3,
+				image: {
+					publicUrl: 'https://example.com/receipt-9.jpg',
+					filePath: '/tmp/receipt-9.jpg',
+					fileName: 'receipt-9.jpg',
+					size: 50,
+				},
+			})
+		).rejects.toThrow('Receipt transaction type could not be normalized');
+	});
 });

--- a/prisma/migrations/20260406183000_add_dashboard_budget_preferences/migration.sql
+++ b/prisma/migrations/20260406183000_add_dashboard_budget_preferences/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `User`
+ADD COLUMN `dashboardBudgetPreferences` JSON NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   email                   String                    @unique @db.VarChar(255)
   createdAt               DateTime                  @default(now())
   aiSettings              AISettings?
+  dashboardBudgetPreferences Json?
   categories              Category[]
   keywords                Keyword[]
   notificationLogs        NotificationLog[]

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -11,6 +11,11 @@ import { NotificationFactory } from '../modules/notifications/notification.modul
 import { NotificationPreferenceInput } from '../src/enums/notifications';
 import { config } from '../src/config';
 import logger from '../src/lib/logger';
+import {
+	DEFAULT_DASHBOARD_BUDGET_PREFERENCES,
+	normalizeDashboardBudgetPreferences,
+	resolveDashboardBudgetPreferences,
+} from '../src/lib/dashboard-budget-preferences';
 import { BaseTransactions, mapTransactionType } from '../modules/base-transactions/base-transactions.module';
 import { areSentryTestEndpointsEnabled } from '../src/lib/sentry-test';
 import { captureException, flushSentry, isSentryEnabled } from '../src/lib/sentry';
@@ -972,6 +977,51 @@ router.delete('/api/budgets/fallback-rules/:sourceCategoryId', requireAuth, asyn
 	} catch (error) {
 		logger.error('Failed to delete budget fallback rule', { error, userId: req.user.id });
 		res.status(500).json({ message: 'Failed to delete budget fallback rule' });
+	}
+});
+
+// ============================================
+// Dashboard Preferences API
+// ============================================
+
+router.get('/api/dashboard/budget-preferences', requireAuth, async (req: Request, res: Response) => {
+	try {
+		const user = await prisma.user.findUnique({
+			where: { id: req.user.id },
+			select: { dashboardBudgetPreferences: true },
+		});
+
+		res.status(200).json(
+			user?.dashboardBudgetPreferences
+				? normalizeDashboardBudgetPreferences(user.dashboardBudgetPreferences)
+				: DEFAULT_DASHBOARD_BUDGET_PREFERENCES
+		);
+	} catch (error) {
+		logger.error('Failed to fetch dashboard budget preferences', { error, userId: req.user.id });
+		res.status(500).json({ message: 'Failed to fetch dashboard budget preferences' });
+	}
+});
+
+router.put('/api/dashboard/budget-preferences', requireAuth, async (req: Request, res: Response) => {
+	try {
+		const user = await prisma.user.findUnique({
+			where: { id: req.user.id },
+			select: { dashboardBudgetPreferences: true },
+		});
+
+		const preferences = resolveDashboardBudgetPreferences(user?.dashboardBudgetPreferences, req.body);
+
+		await prisma.user.update({
+			where: { id: req.user.id },
+			data: {
+				dashboardBudgetPreferences: preferences as unknown as Prisma.InputJsonValue,
+			},
+		});
+
+		res.status(200).json(preferences);
+	} catch (error) {
+		logger.error('Failed to update dashboard budget preferences', { error, userId: req.user.id });
+		res.status(500).json({ message: 'Failed to update dashboard budget preferences' });
 	}
 });
 

--- a/src/lib/dashboard-budget-preferences.ts
+++ b/src/lib/dashboard-budget-preferences.ts
@@ -1,0 +1,74 @@
+export type DashboardBudgetSort = 'manual' | 'name' | 'most-spent';
+
+export interface DashboardBudgetPreferences {
+	sortBy: DashboardBudgetSort;
+	hiddenBudgetIds: number[];
+	manualBudgetOrderIds: number[];
+}
+
+export const DEFAULT_DASHBOARD_BUDGET_PREFERENCES: DashboardBudgetPreferences = {
+	sortBy: 'manual',
+	hiddenBudgetIds: [],
+	manualBudgetOrderIds: [],
+};
+
+const validSorts = new Set<DashboardBudgetSort>(['manual', 'name', 'most-spent']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function sanitizeBudgetIds(value: unknown): number[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	const uniqueIds = new Set<number>();
+
+	for (const entry of value) {
+		if (typeof entry === 'number' && Number.isInteger(entry) && entry > 0) {
+			uniqueIds.add(entry);
+		}
+	}
+
+	return [...uniqueIds];
+}
+
+export function normalizeDashboardBudgetPreferences(value: unknown): DashboardBudgetPreferences {
+	if (!isRecord(value)) {
+		return { ...DEFAULT_DASHBOARD_BUDGET_PREFERENCES };
+	}
+
+	const sortBy = validSorts.has(value.sortBy as DashboardBudgetSort)
+		? (value.sortBy as DashboardBudgetSort)
+		: DEFAULT_DASHBOARD_BUDGET_PREFERENCES.sortBy;
+
+	return {
+		sortBy,
+		hiddenBudgetIds: sanitizeBudgetIds(value.hiddenBudgetIds),
+		manualBudgetOrderIds: sanitizeBudgetIds(value.manualBudgetOrderIds),
+	};
+}
+
+export function resolveDashboardBudgetPreferences(
+	currentValue: unknown,
+	patchValue: unknown
+): DashboardBudgetPreferences {
+	const current = normalizeDashboardBudgetPreferences(currentValue);
+
+	if (!isRecord(patchValue)) {
+		return current;
+	}
+
+	return {
+		sortBy: validSorts.has(patchValue.sortBy as DashboardBudgetSort)
+			? (patchValue.sortBy as DashboardBudgetSort)
+			: current.sortBy,
+		hiddenBudgetIds: Array.isArray(patchValue.hiddenBudgetIds)
+			? sanitizeBudgetIds(patchValue.hiddenBudgetIds)
+			: current.hiddenBudgetIds,
+		manualBudgetOrderIds: Array.isArray(patchValue.manualBudgetOrderIds)
+			? sanitizeBudgetIds(patchValue.manualBudgetOrderIds)
+			: current.manualBudgetOrderIds,
+	};
+}

--- a/tests/ai-assistant-controller.test.ts
+++ b/tests/ai-assistant-controller.test.ts
@@ -29,6 +29,7 @@ jest.mock('../src/lib/receipt-image-storage', () => ({
 
 jest.mock('../src/lib/sentry', () => ({
 	captureException: jest.fn(),
+	captureLog: jest.fn(),
 }));
 
 const optimizeReceiptImageForOcrMock = jest.mocked(optimizeReceiptImageForOcr);

--- a/tests/ai-assistant-controller.test.ts
+++ b/tests/ai-assistant-controller.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { Request, Response } from 'express';
+import { queueReceiptAnalysis } from '../controllers/ai-assistant/ai-assistant.controller';
 
 type MockOptimizedReceiptImage = {
 	buffer: Buffer;
@@ -60,8 +61,6 @@ jest.mock('../src/lib/receipt-image-storage', () => ({
 jest.mock('../src/lib/sentry', () => ({
 	captureException: jest.fn(),
 }));
-
-import { queueReceiptAnalysis } from '../controllers/ai-assistant/ai-assistant.controller';
 
 function createResponse() {
 	const json = jest.fn();

--- a/tests/ai-assistant-controller.test.ts
+++ b/tests/ai-assistant-controller.test.ts
@@ -1,42 +1,11 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { Request, Response } from 'express';
 import { queueReceiptAnalysis } from '../controllers/ai-assistant/ai-assistant.controller';
-
-type MockOptimizedReceiptImage = {
-	buffer: Buffer;
-	mimeType: string;
-	compressionIterations: number;
-	compressionQuality: number | null;
-	targetMaxBytes: number | null;
-	targetReached: boolean;
-	originalBytes: number;
-	optimizedBytes: number;
-	originalWidth: number | null;
-	originalHeight: number | null;
-	optimizedWidth: number | null;
-	optimizedHeight: number | null;
-	originalFormat: string | null;
-	optimizedFormat: string | null;
-	didOptimize: boolean;
-};
-
-type MockStoredReceiptImage = {
-	publicUrl: string;
-	filePath: string;
-	fileName: string;
-};
-
-type MockQueuedJobSummary = {
-	id: string;
-	status: string;
-};
-
-const enqueueJobsMock = jest.fn<(userId: number, files: unknown[]) => Promise<MockQueuedJobSummary[]>>();
-const optimizeReceiptImageForOcrMock = jest.fn<(buffer: Buffer) => Promise<MockOptimizedReceiptImage>>();
-const saveReceiptProcessingImageMock = jest.fn<
-	(params: { requestId: string }) => Promise<MockStoredReceiptImage>
->();
-
+import { ReceiptOcrQueueService } from '../modules/ai-assistant/receipt-ocr-queue.service';
+import {
+	optimizeReceiptImageForOcr,
+	saveReceiptProcessingImage,
+} from '../src/lib/receipt-image-storage';
 jest.mock('../modules/ai-assistant/ai-assistant.module', () => ({
 	AISettingsService: {},
 	AIAssistantFactory: {},
@@ -48,19 +17,23 @@ jest.mock('../modules/database/database.module', () => ({
 
 jest.mock('../modules/ai-assistant/receipt-ocr-queue.service', () => ({
 	ReceiptOcrQueueService: {
-		enqueueJobs: enqueueJobsMock,
+		enqueueJobs: jest.fn(),
 	},
 }));
 
 jest.mock('../src/lib/receipt-image-storage', () => ({
 	getImageExtension: jest.fn(),
-	optimizeReceiptImageForOcr: optimizeReceiptImageForOcrMock,
-	saveReceiptProcessingImage: saveReceiptProcessingImageMock,
+	optimizeReceiptImageForOcr: jest.fn(),
+	saveReceiptProcessingImage: jest.fn(),
 }));
 
 jest.mock('../src/lib/sentry', () => ({
 	captureException: jest.fn(),
 }));
+
+const optimizeReceiptImageForOcrMock = jest.mocked(optimizeReceiptImageForOcr);
+const saveReceiptProcessingImageMock = jest.mocked(saveReceiptProcessingImage);
+const enqueueJobsMock = jest.mocked(ReceiptOcrQueueService.enqueueJobs);
 
 function createResponse() {
 	const json = jest.fn();
@@ -100,7 +73,29 @@ describe('AI Assistant Controller', () => {
 			fileName: `${requestId}.jpg`,
 		}));
 
-		enqueueJobsMock.mockResolvedValue([{ id: 'job-1', status: 'queued' }]);
+		enqueueJobsMock.mockResolvedValue([
+			{
+				id: 'job-1',
+				status: 'queued',
+				attempts: 0,
+				maxAttempts: 3,
+				reviewStatus: 'pending_review',
+				reviewedAt: null,
+				createdAt: '2026-04-06T00:00:00.000Z',
+				updatedAt: '2026-04-06T00:00:00.000Z',
+				requestId: 'req-123',
+				timeZone: null,
+				image: {
+					publicUrl: 'https://api.zentra-app.pro/receipt-processing/req-123.jpg',
+					fileName: 'req-123.jpg',
+					originalName: 'WhatsApp Image 2026-04-02 at 15.26.02.jpeg',
+					mimeType: 'image/jpeg',
+					size: 12345,
+				},
+				error: null,
+				result: null,
+			},
+		]);
 	});
 
 	it('preserves the uploaded original filename when queueing receipts', async () => {
@@ -110,6 +105,7 @@ describe('AI Assistant Controller', () => {
 				firebaseId: 'firebase-user-1',
 				email: 'test@example.com',
 				createdAt: new Date('2026-04-06T00:00:00.000Z'),
+				dashboardBudgetPreferences: null,
 			},
 			body: {},
 			files: [

--- a/tests/ai-assistant-routes.test.ts
+++ b/tests/ai-assistant-routes.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { NextFunction, Request, Response } from 'express';
+import app from '../app';
 
 const queueReceiptAnalysisMock = jest.fn(
 	async (req: Request, res: Response): Promise<void> => {
@@ -41,8 +42,6 @@ jest.mock('../controllers/ai-assistant/ai-assistant.controller', () => ({
 	analyzeTransactions: jest.fn(),
 	getBudgetSuggestions: jest.fn(),
 }));
-
-import app from '../app';
 
 describe('AI Assistant Routes', () => {
 	beforeEach(() => {

--- a/tests/ai-assistant-routes.test.ts
+++ b/tests/ai-assistant-routes.test.ts
@@ -2,21 +2,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { NextFunction, Request, Response } from 'express';
 import app from '../app';
-
-const queueReceiptAnalysisMock = jest.fn(
-	async (req: Request, res: Response): Promise<void> => {
-		const files = req.files as Express.Multer.File[] | Record<string, Express.Multer.File[]> | undefined;
-		const fileCount = Array.isArray(files)
-			? files.length
-			: files
-				? Object.values(files).flat().length
-				: req.file
-					? 1
-					: 0;
-
-		res.status(200).json({ fileCount });
-	}
-);
+import * as AIController from '../controllers/ai-assistant/ai-assistant.controller';
 
 jest.mock('../src/lib/auth.middleware', () => ({
 	requireAuth: (req: Request, _res: Response, next: NextFunction) => {
@@ -25,6 +11,7 @@ jest.mock('../src/lib/auth.middleware', () => ({
 			firebaseId: 'firebase-user-1',
 			email: 'test@example.com',
 			createdAt: new Date('2026-04-06T00:00:00.000Z'),
+			dashboardBudgetPreferences: null,
 		};
 		next();
 	},
@@ -34,7 +21,7 @@ jest.mock('../controllers/ai-assistant/ai-assistant.controller', () => ({
 	getAISettings: jest.fn(),
 	updateAISettings: jest.fn(),
 	scanReceipt: jest.fn(),
-	queueReceiptAnalysis: queueReceiptAnalysisMock,
+	queueReceiptAnalysis: jest.fn(),
 	getQueuedReceiptAnalysisJobs: jest.fn(),
 	retryQueuedReceiptAnalysisJob: jest.fn(),
 	markQueuedReceiptAnalysisJobReviewed: jest.fn(),
@@ -43,9 +30,23 @@ jest.mock('../controllers/ai-assistant/ai-assistant.controller', () => ({
 	getBudgetSuggestions: jest.fn(),
 }));
 
+const queueReceiptAnalysisMock = jest.mocked(AIController.queueReceiptAnalysis);
+
 describe('AI Assistant Routes', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		queueReceiptAnalysisMock.mockImplementation(async (req: Request, res: Response): Promise<void> => {
+			const files = req.files as Express.Multer.File[] | Record<string, Express.Multer.File[]> | undefined;
+			const fileCount = Array.isArray(files)
+				? files.length
+				: files
+					? Object.values(files).flat().length
+					: req.file
+						? 1
+						: 0;
+
+			res.status(200).json({ fileCount });
+		});
 	});
 
 	it('accepts bulk receipt uploads under the images field', async () => {

--- a/tests/dashboard-budget-preferences-routes.test.ts
+++ b/tests/dashboard-budget-preferences-routes.test.ts
@@ -1,0 +1,105 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import app from '../app';
+import { prismaMock } from '../modules/database/database.module.mock';
+
+jest.mock('../src/lib/auth.middleware', () => ({
+	requireAuth: (req: any, _res: any, next: any) => {
+		req.user = { id: 1, email: 'test@example.com' };
+		next();
+	},
+}));
+
+describe('Dashboard Budget Preferences Routes', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns default preferences when the user has not saved any', async () => {
+		prismaMock.user.findUnique.mockResolvedValue({
+			dashboardBudgetPreferences: null,
+		} as never);
+
+		const response = await request(app).get('/api/dashboard/budget-preferences');
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({
+			sortBy: 'manual',
+			hiddenBudgetIds: [],
+			manualBudgetOrderIds: [],
+		});
+		expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+			where: { id: 1 },
+			select: { dashboardBudgetPreferences: true },
+		});
+	});
+
+	it('updates dashboard preferences with sanitized ids and preserves current values for omitted fields', async () => {
+		prismaMock.user.findUnique.mockResolvedValue({
+			dashboardBudgetPreferences: {
+				sortBy: 'name',
+				hiddenBudgetIds: [2],
+				manualBudgetOrderIds: [3, 1, 2],
+			},
+		} as never);
+
+		prismaMock.user.update.mockResolvedValue({
+			id: 1,
+			dashboardBudgetPreferences: {
+				sortBy: 'name',
+				hiddenBudgetIds: [5],
+				manualBudgetOrderIds: [7, 3],
+			},
+		} as never);
+
+		const response = await request(app)
+			.put('/api/dashboard/budget-preferences')
+			.send({
+				hiddenBudgetIds: [5, 5, -1, 'bad'],
+				manualBudgetOrderIds: [7, 3, 7, 0],
+			});
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({
+			sortBy: 'name',
+			hiddenBudgetIds: [5],
+			manualBudgetOrderIds: [7, 3],
+		});
+		expect(prismaMock.user.update).toHaveBeenCalledWith({
+			where: { id: 1 },
+			data: {
+				dashboardBudgetPreferences: {
+					sortBy: 'name',
+					hiddenBudgetIds: [5],
+					manualBudgetOrderIds: [7, 3],
+				},
+			},
+		});
+	});
+
+	it('accepts explicit sort updates', async () => {
+		prismaMock.user.findUnique.mockResolvedValue({
+			dashboardBudgetPreferences: {
+				sortBy: 'manual',
+				hiddenBudgetIds: [],
+				manualBudgetOrderIds: [1, 2, 3],
+			},
+		} as never);
+
+		prismaMock.user.update.mockResolvedValue({
+			id: 1,
+			dashboardBudgetPreferences: {
+				sortBy: 'most-spent',
+				hiddenBudgetIds: [],
+				manualBudgetOrderIds: [1, 2, 3],
+			},
+		} as never);
+
+		const response = await request(app)
+			.put('/api/dashboard/budget-preferences')
+			.send({ sortBy: 'most-spent' });
+
+		expect(response.status).toBe(200);
+		expect(response.body.sortBy).toBe('most-spent');
+	});
+});

--- a/tests/transaction-crud.test.ts
+++ b/tests/transaction-crud.test.ts
@@ -126,7 +126,11 @@ describe('Transaction API (CRUD)', () => {
 		});
 		expect(prismaMock.transaction.update).toHaveBeenCalledWith({
 			where: { id: 22 },
-			data: { categoryId: 2 },
+			data: expect.objectContaining({
+				categoryId: 2,
+				reviewed: true,
+				reviewedAt: expect.any(Date),
+			}),
 			include: {
 				category: true,
 				paymentMethod: true,
@@ -310,9 +314,11 @@ describe('Transaction API (CRUD)', () => {
 					in: [55, 56],
 				},
 			},
-			data: {
+			data: expect.objectContaining({
 				categoryId: 4,
-			},
+				reviewed: true,
+				reviewedAt: expect.any(Date),
+			}),
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- persist per-user dashboard budget preferences on the backend
- let the dashboard hide budgets and sort by manual order, name, or most spent
- add settings controls and tests for dashboard budget visibility/order

## Testing
- npx prisma generate
- npx jest tests/dashboard-budget-preferences-routes.test.ts --runInBand --watchman=false --coverage=false
- npx eslint routes/router.ts src/lib/dashboard-budget-preferences.ts tests/dashboard-budget-preferences-routes.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard budget preferences: choose sort order (manual, name, most-spent), hide budgets, and set a manual budget order; preferences persist to your account via new GET/PUT endpoints.
* **Behavior**
  * Inputs validated and sanitized (duplicates/invalid IDs removed); APIs return sensible defaults when unset and surface clear error responses on failure.
* **Tests**
  * Expanded test coverage for preferences endpoints, receipt processing, job queueing, and transaction updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->