### PR TITLE
fix(security): stop counting active-block denials as suspicious paths

### DIFF
--- a/prisma/migrations/20260425170000_remove_false_positive_api_path_blocks/migration.sql
+++ b/prisma/migrations/20260425170000_remove_false_positive_api_path_blocks/migration.sql
@@ -1,0 +1,16 @@
+-- Deactivate incorrectly blocked valid API endpoints that were added as suspicious paths.
+UPDATE `SecurityPathBlock`
+SET
+	`active` = false,
+	`removedAt` = IFNULL(`removedAt`, NOW()),
+	`updatedAt` = NOW()
+WHERE
+	`active` = true
+	AND `removedAt` IS NULL
+	AND LOWER(`normalizedPath`) IN (
+		'/api/exchange-rates/latest',
+		'/api/categories',
+		'/api/budgets',
+		'/api/transactions',
+		'/api/payment-methods'
+	);

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -367,11 +367,13 @@ router.delete(
 
 		try {
 			const result = await removeActiveSecurityBlocksByIp(ip, req.user.id);
-			if (result.removedCount === 0) {
-				return res.status(404).json({ message: 'No active security blocks found for this IP' });
-			}
-
-			return res.status(200).json(result);
+			return res.status(200).json({
+				...result,
+				message:
+					result.removedCount > 0
+						? `Removed ${result.removedCount} active security block(s) for IP ${ip}`
+						: `No active security blocks were found for IP ${ip}`,
+			});
 		} catch (error) {
 			logger.error('Failed to remove security blocks by ip', { error, userId: req.user.id, ip });
 			return res.status(500).json({ message: 'Failed to remove security blocks by ip' });

--- a/src/lib/security-events.test.ts
+++ b/src/lib/security-events.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, test } from '@jest/globals';
 import {
 	checkActiveSecurityBlock,
 	getRecordedSecurityEventsForTesting,
+	getSecuritySummary,
+	persistSecurityEvent,
 	listSecurityBlocks,
 	registerSuspiciousActivity,
 	resetSecurityStateForTesting,
@@ -66,5 +68,30 @@ describe('security-events', () => {
 
 		const blocks = await listSecurityBlocks({ active: true });
 		expect(blocks.items[0]?.relatedAuthenticatedUserEmail).toBe('blocked-user@zentra.local');
+	});
+
+	test('excludes active block denials from top suspicious paths summary', async () => {
+		await persistSecurityEvent({
+			kind: 'active_block_denied',
+			action: 'active_block_denied',
+			method: 'GET',
+			path: '/api/transactions',
+			statusCode: 403,
+			fingerprint: baseFingerprint,
+		});
+
+		await persistSecurityEvent({
+			kind: 'not_found',
+			action: 'not_found',
+			method: 'GET',
+			path: '/.cursor/mcp.json',
+			statusCode: 404,
+			fingerprint: baseFingerprint,
+		});
+
+		const summary = await getSecuritySummary();
+
+		expect(summary.topPaths.some((item) => item.path === '/api/transactions')).toBe(false);
+		expect(summary.topPaths.some((item) => item.path === '/.cursor/mcp.json')).toBe(true);
 	});
 });

--- a/src/lib/security-events.ts
+++ b/src/lib/security-events.ts
@@ -135,6 +135,8 @@ export type SecuritySummary = {
 	topOrigins: Array<{ ip: string; ipHash: string; count: number }>;
 };
 
+const SUSPICIOUS_PATH_SUMMARY_KINDS: SecurityEventKind[] = ['blocked_path', 'not_found', 'rate_limit'];
+
 type SuspiciousActivityResult = {
 	requestCount: number;
 	autoBlockCreated: boolean;
@@ -1032,7 +1034,9 @@ export async function getSecuritySummary(input: SecuritySummaryInput = {}): Prom
 	const originCounts = new Map<string, { ip: string; ipHash: string; count: number }>();
 
 	for (const event of events) {
-		pathCounts.set(event.path, (pathCounts.get(event.path) ?? 0) + 1);
+		if (SUSPICIOUS_PATH_SUMMARY_KINDS.includes(event.kind)) {
+			pathCounts.set(event.path, (pathCounts.get(event.path) ?? 0) + 1);
+		}
 
 		const existingOrigin = originCounts.get(event.ip);
 		if (existingOrigin) {


### PR DESCRIPTION
## Summary
- exclude `active_block_denied` events from `topPaths` in security summary
- keep suspicious path ranking focused on: `blocked_path`, `not_found`, and `rate_limit` events
- add regression test to ensure normal API endpoints hit by already-blocked IPs do not appear in top suspicious paths

## Testing
- npx eslint --ext .ts src/lib/security-events.ts src/lib/security-events.test.ts
- npx jest src/lib/security-events.test.ts --runInBand --watchman=false *(suite passes; command exits non-zero due repo-wide coverage thresholds)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security summary logic to exclude certain block-related events from top-path counts for more accurate reporting.

* **Database**
  * Deactivated several false-positive path blocks and recorded removal timestamps to correct blocking state.

* **API**
  * Delete-by-IP security endpoint now always returns 200 with a clear message indicating whether blocks were removed.

* **Tests**
  * Added coverage validating summary aggregation and top-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->