### PR TITLE
fix(security): enforce active blocks on health and OPTIONS

### DIFF
--- a/src/lib/request-security.ts
+++ b/src/lib/request-security.ts
@@ -476,11 +476,6 @@ export function blockSuspiciousPathsMiddleware(req: Request, res: Response, next
 }
 
 export function activeSecurityBlockMiddleware(req: Request, res: Response, next: NextFunction): void {
-	if (req.method === 'OPTIONS' || req.path === '/health') {
-		next();
-		return;
-	}
-
 	const baseFingerprint = collectSecurityFingerprint(req);
 	checkActiveSecurityBlock(baseFingerprint.ip)
 		.then(async ({ blocked, blockId }) => {

--- a/tests/security-hardening.test.ts
+++ b/tests/security-hardening.test.ts
@@ -68,6 +68,32 @@ describe('Security hardening', () => {
 		expect(events.some((event) => event.kind === 'active_block_denied' && event.path === '/')).toBe(true);
 	});
 
+	it('applies active security block to /health checks', async () => {
+		const ip = '198.51.100.78';
+
+		await request(app).get('/.env').set('X-Forwarded-For', ip);
+		await request(app).get('/appsettings.json').set('X-Forwarded-For', ip);
+		await request(app).get('/.git/config').set('X-Forwarded-For', ip);
+
+		const blockedHealth = await request(app).get('/health').set('X-Forwarded-For', ip);
+
+		expect(blockedHealth.status).toBe(403);
+		expect(blockedHealth.text).toBe('Forbidden');
+	});
+
+	it('applies active security block to OPTIONS requests', async () => {
+		const ip = '198.51.100.79';
+
+		await request(app).get('/.env').set('X-Forwarded-For', ip);
+		await request(app).get('/appsettings.json').set('X-Forwarded-For', ip);
+		await request(app).get('/.git/config').set('X-Forwarded-For', ip);
+
+		const blockedOptions = await request(app).options('/').set('X-Forwarded-For', ip);
+
+		expect(blockedOptions.status).toBe(403);
+		expect(blockedOptions.text).toBe('Forbidden');
+	});
+
 	it('collects enriched attacker context from headers', () => {
 		const details = collectSecurityRequestDetails({
 			ip: '::ffff:203.0.113.99',


### PR DESCRIPTION
## Summary
- remove `/health` and `OPTIONS` bypass from `activeSecurityBlockMiddleware`
- ensure actively blocked IPs are denied consistently across health and preflight requests
- add regression tests for blocked `GET /health` and blocked `OPTIONS /`

## Validation
- `npm run lint` (passes, but note this script runs `lint-staged` and reports no staged files)
- `npx eslint . --ext .ts --max-warnings=0` ✅
- `npm run build` ❌ (fails in this environment with existing TypeScript type-resolution errors such as `Cannot find type definition file for "node 2"`)
- `npx jest tests/security-hardening.test.ts --runInBand --watchman=false --coverage=false` ✅ (8 passing tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Security middleware now enforces blocking rules on all request types, including health checks and preflight requests, returning HTTP 403 responses when active security blocks match.

* **Tests**
  * Added integration tests verifying security block enforcement for health check and preflight requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->