### PR TITLE
feat(budgets): add goals and transaction metadata

### DIFF
--- a/controllers/ai-assistant/ai-assistant.controller.ts
+++ b/controllers/ai-assistant/ai-assistant.controller.ts
@@ -207,6 +207,7 @@ async function optimizeAndStoreReceiptFile(params: {
   requestId: string;
   baseUrl: string;
   label: string;
+  publicSubdir?: 'receipt-processing' | 'receipt-review';
 }) {
   const optimizationDetails = await optimizeReceiptImageForOcr(params.file.buffer);
   const mimeType = optimizationDetails.didOptimize
@@ -222,6 +223,7 @@ async function optimizeAndStoreReceiptFile(params: {
     requestId: params.requestId,
     baseUrl: params.baseUrl,
     label: params.label,
+    publicSubdir: params.publicSubdir,
   });
 
   return {
@@ -263,6 +265,7 @@ export async function queueReceiptAnalysis(req: Request, res: Response): Promise
         requestId,
         baseUrl,
         label: `queue-${index + 1}`,
+        publicSubdir: 'receipt-review',
       });
 
       queuedFiles.push({

--- a/controllers/categories.controller.ts
+++ b/controllers/categories.controller.ts
@@ -11,6 +11,52 @@ type CategoryWithOptionalIcon = {
 	icon?: string | null;
 };
 
+type BudgetType = 'spending' | 'recurring' | 'goal' | 'reserve';
+
+const BUDGET_TYPES = new Set<BudgetType>(['spending', 'recurring', 'goal', 'reserve']);
+
+function normalizeBudgetType(value: unknown): BudgetType {
+	return typeof value === 'string' && BUDGET_TYPES.has(value as BudgetType) ? value as BudgetType : 'spending';
+}
+
+function normalizeOptionalAmount(value: unknown): number | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || value === '') return null;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function normalizeOptionalDueDay(value: unknown): number | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || value === '') return null;
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed >= 1 && parsed <= 31 ? parsed : null;
+}
+
+function normalizeOptionalTargetDate(value: unknown): Date | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || value === '') return null;
+	if (typeof value !== 'string') return null;
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function mapCategoryBudgetFields(category: {
+	budgetType?: string | null;
+	targetAmount?: unknown;
+	currentAmount?: unknown;
+	dueDay?: number | null;
+	targetDate?: Date | string | null;
+}) {
+	return {
+		budgetType: normalizeBudgetType(category.budgetType),
+		targetAmount: category.targetAmount === null || category.targetAmount === undefined ? null : Number(category.targetAmount),
+		currentAmount: category.currentAmount === null || category.currentAmount === undefined ? null : Number(category.currentAmount),
+		dueDay: category.dueDay ?? null,
+		targetDate: category.targetDate ? new Date(category.targetDate).toISOString() : null,
+	};
+}
+
 /**
  * Returns all categories for the authenticated user, 
  * including their keywords and transaction counts.
@@ -42,6 +88,7 @@ export async function getCategories(req: Request, res: Response): Promise<void> 
 				icon: (cat as unknown as CategoryWithOptionalIcon).icon ?? null,
 				amountLimit: Number(cat.amountLimit ?? 0),
 				isCumulative: cat.isCumulative,
+				...mapCategoryBudgetFields(cat),
 				currentCarryOver: Number(period?.carryOver || 0),
 				keywords: cat.categoryKeyword.map((ck) => ck.keyword.name),
 				transactionCount: cat._count.transaction,
@@ -59,13 +106,18 @@ export async function getCategories(req: Request, res: Response): Promise<void> 
  * Creates a new category and associates keywords.
  */
 export async function createCategory(req: Request, res: Response): Promise<void> {
-	const { name, description, icon, amountLimit, keywords, isCumulative } = req.body as {
+	const { name, description, icon, amountLimit, keywords, isCumulative, budgetType, targetAmount, currentAmount, dueDay, targetDate } = req.body as {
 		name: string;
 		description?: string;
 		icon?: string;
 		amountLimit?: number;
 		keywords?: string[];
 		isCumulative?: boolean;
+		budgetType?: string;
+		targetAmount?: number | null;
+		currentAmount?: number | null;
+		dueDay?: number | null;
+		targetDate?: string | null;
 	};
 
 	if (!name) {
@@ -75,6 +127,12 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 
 	try {
 		logger.info('API: Creating category', { userId: req.user.id, name });
+		const normalizedBudgetType = normalizeBudgetType(budgetType);
+		const normalizedTargetAmount = normalizeOptionalAmount(targetAmount);
+		const normalizedCurrentAmount = normalizeOptionalAmount(currentAmount);
+		const normalizedDueDay = normalizeOptionalDueDay(dueDay);
+		const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
+
 		const result = await prisma.$transaction(async (tx) => {
 			// 1. Create the category
 			const categoryCreateData = {
@@ -82,6 +140,11 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 					description,
 					icon: icon ?? null,
 					amountLimit,
+					budgetType: normalizedBudgetType,
+					targetAmount: normalizedTargetAmount === undefined ? null : normalizedTargetAmount,
+					currentAmount: normalizedCurrentAmount === undefined ? null : normalizedCurrentAmount,
+					dueDay: normalizedDueDay === undefined ? null : normalizedDueDay,
+					targetDate: normalizedTargetDate === undefined ? null : normalizedTargetDate,
 					isCumulative: !!isCumulative,
 					userId: req.user.id,
 				};
@@ -119,7 +182,11 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 			return category;
 		});
 
-		res.status(201).json(result);
+		res.status(201).json({
+			...result,
+			amountLimit: Number(result.amountLimit ?? 0),
+			...mapCategoryBudgetFields(result),
+		});
 	} catch (error: unknown) {
 		const prismaError = error instanceof Prisma.PrismaClientKnownRequestError ? error : null;
 		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -139,13 +206,18 @@ export async function createCategory(req: Request, res: Response): Promise<void>
  */
 export async function updateCategory(req: Request, res: Response): Promise<void> {
 	const id = Number(req.params.id);
-	const { name, description, icon, amountLimit, keywords, isCumulative } = req.body as {
+	const { name, description, icon, amountLimit, keywords, isCumulative, budgetType, targetAmount, currentAmount, dueDay, targetDate } = req.body as {
 		name?: string;
 		description?: string;
 		icon?: string;
 		amountLimit?: number;
 		keywords?: string[];
 		isCumulative?: boolean;
+		budgetType?: string;
+		targetAmount?: number | null;
+		currentAmount?: number | null;
+		dueDay?: number | null;
+		targetDate?: string | null;
 	};
 
 	if (isNaN(id)) {
@@ -179,12 +251,22 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 				}
 			}
 
+			const normalizedTargetAmount = normalizeOptionalAmount(targetAmount);
+			const normalizedCurrentAmount = normalizeOptionalAmount(currentAmount);
+			const normalizedDueDay = normalizeOptionalDueDay(dueDay);
+			const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
+
 			// 1. Update category fields
 			const categoryUpdateData = {
 						name: name ?? existing.name,
 						description: description !== undefined ? description : existing.description,
 						icon: icon !== undefined ? icon : (existing as unknown as CategoryWithOptionalIcon).icon,
 						amountLimit: amountLimit !== undefined ? amountLimit : existing.amountLimit,
+						budgetType: budgetType !== undefined ? normalizeBudgetType(budgetType) : existing.budgetType,
+						targetAmount: normalizedTargetAmount !== undefined ? normalizedTargetAmount : existing.targetAmount,
+						currentAmount: normalizedCurrentAmount !== undefined ? normalizedCurrentAmount : existing.currentAmount,
+						dueDay: normalizedDueDay !== undefined ? normalizedDueDay : existing.dueDay,
+						targetDate: normalizedTargetDate !== undefined ? normalizedTargetDate : existing.targetDate,
 						isCumulative: isCumulative !== undefined ? isCumulative : existing.isCumulative,
 					};
 			const updatedCategory = await tx.category.update({
@@ -228,7 +310,11 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 			return updatedCategory;
 		});
 
-		res.status(200).json(result);
+		res.status(200).json({
+			...result,
+			amountLimit: Number(result.amountLimit ?? 0),
+			...mapCategoryBudgetFields(result),
+		});
 	} catch (error: unknown) {
 		if (error instanceof Error && error.message === 'Category not found') {
 			res.status(404).json({ message: error.message });

--- a/controllers/categories.controller.ts
+++ b/controllers/categories.controller.ts
@@ -3,6 +3,12 @@ import { Prisma } from '@prisma/client';
 import { PrismaModule as prisma } from '../modules/database/database.module';
 import logger from '../src/lib/logger';
 import { BudgetRollover } from '../modules/budgets/budget-rollover.service';
+import {
+	normalizeBudgetType,
+	normalizeOptionalAmount,
+	normalizeOptionalDueDay,
+	normalizeOptionalTargetDate,
+} from '../src/lib/budget-normalizers';
 
 const normalizeKeywords = (keywords: string[]): string[] =>
 	[...new Set(keywords.map((keyword) => keyword.trim().toLowerCase()).filter(Boolean))];
@@ -10,36 +16,6 @@ const normalizeKeywords = (keywords: string[]): string[] =>
 type CategoryWithOptionalIcon = {
 	icon?: string | null;
 };
-
-type BudgetType = 'spending' | 'recurring' | 'goal' | 'reserve';
-
-const BUDGET_TYPES = new Set<BudgetType>(['spending', 'recurring', 'goal', 'reserve']);
-
-function normalizeBudgetType(value: unknown): BudgetType {
-	return typeof value === 'string' && BUDGET_TYPES.has(value as BudgetType) ? value as BudgetType : 'spending';
-}
-
-function normalizeOptionalAmount(value: unknown): number | null | undefined {
-	if (value === undefined) return undefined;
-	if (value === null || value === '') return null;
-	const parsed = Number(value);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
-}
-
-function normalizeOptionalDueDay(value: unknown): number | null | undefined {
-	if (value === undefined) return undefined;
-	if (value === null || value === '') return null;
-	const parsed = Number(value);
-	return Number.isInteger(parsed) && parsed >= 1 && parsed <= 31 ? parsed : null;
-}
-
-function normalizeOptionalTargetDate(value: unknown): Date | null | undefined {
-	if (value === undefined) return undefined;
-	if (value === null || value === '') return null;
-	if (typeof value !== 'string') return null;
-	const parsed = new Date(value);
-	return Number.isNaN(parsed.getTime()) ? null : parsed;
-}
 
 function mapCategoryBudgetFields(category: {
 	budgetType?: string | null;

--- a/prisma/migrations/20260608120000_add_transaction_manual_location_fields/migration.sql
+++ b/prisma/migrations/20260608120000_add_transaction_manual_location_fields/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `Transaction`
+ADD COLUMN `manualDescription` VARCHAR(255) NULL,
+ADD COLUMN `locationName` VARCHAR(255) NULL,
+ADD COLUMN `latitude` DECIMAL(10, 7) NULL,
+ADD COLUMN `longitude` DECIMAL(10, 7) NULL,
+ADD COLUMN `googleMapsUrl` VARCHAR(500) NULL;

--- a/prisma/migrations/20260608130000_add_budget_types/migration.sql
+++ b/prisma/migrations/20260608130000_add_budget_types/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `Category`
+ADD COLUMN `budgetType` VARCHAR(20) NOT NULL DEFAULT 'spending',
+ADD COLUMN `targetAmount` DECIMAL(10, 2) NULL,
+ADD COLUMN `currentAmount` DECIMAL(10, 2) NULL,
+ADD COLUMN `dueDay` INTEGER NULL,
+ADD COLUMN `targetDate` DATETIME(3) NULL;

--- a/prisma/migrations/20260608143000_add_budget_due_day_check/migration.sql
+++ b/prisma/migrations/20260608143000_add_budget_due_day_check/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `Category`
+  ADD CONSTRAINT `chk_Category_dueDay_range`
+  CHECK (`dueDay` IS NULL OR (`dueDay` >= 1 AND `dueDay` <= 31));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,11 @@ model Category {
   description      String?           @db.VarChar(255)
   icon             String?           @db.VarChar(50)
   amountLimit      Decimal?          @db.Decimal(10, 2)
+  budgetType       String            @default("spending") @db.VarChar(20)
+  targetAmount     Decimal?          @db.Decimal(10, 2)
+  currentAmount    Decimal?          @db.Decimal(10, 2)
+  dueDay           Int?
+  targetDate       DateTime?
   isCumulative     Boolean           @default(false)
   userId           Int
   user             User              @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -128,6 +133,11 @@ model Transaction {
   isMonthly              Boolean        @default(false)
   shopId                 Int?
   referenceId            String?        @db.VarChar(30)
+  manualDescription      String?        @db.VarChar(255)
+  locationName           String?        @db.VarChar(255)
+  latitude               Decimal?       @db.Decimal(10, 7)
+  longitude              Decimal?       @db.Decimal(10, 7)
+  googleMapsUrl          String?        @db.VarChar(500)
   isAnnually             Boolean        @default(false)
   originalCurrencyAmount Decimal?       @db.Decimal(10, 2)
   telegramFileIds        String?        @db.VarChar(255)

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -604,6 +604,11 @@ router.get('/api/transactions', requireAuth, async (req: Request, res: Response)
 			type: tx.type === 'credit' ? 'income' : 'expense',
 			source: 'manual',
 			referenceId: tx.referenceId ?? undefined,
+			manualDescription: tx.manualDescription ?? undefined,
+			locationName: tx.locationName ?? undefined,
+			latitude: tx.latitude === null ? undefined : Number(tx.latitude),
+			longitude: tx.longitude === null ? undefined : Number(tx.longitude),
+			googleMapsUrl: tx.googleMapsUrl ?? undefined,
 			currency: tx.currency,
 			reviewed: tx.reviewed,
 		}));
@@ -644,7 +649,7 @@ router.get('/api/exchange-rates/latest', requireAuth, async (req: Request, res: 
 
 router.post('/api/transactions', requireAuth, async (req: Request, res: Response) => {
 	try {
-		const { date, description, amount, category, type, paymentMethodId, currency } = req.body as {
+		const { date, description, amount, category, type, paymentMethodId, currency, manualDescription, locationName, latitude, longitude, googleMapsUrl } = req.body as {
 			date?: string;
 			description?: string;
 			amount?: number;
@@ -652,6 +657,11 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			type?: 'income' | 'expense';
 			paymentMethodId?: number;
 			currency?: string;
+			manualDescription?: string;
+			locationName?: string;
+			latitude?: number;
+			longitude?: number;
+			googleMapsUrl?: string;
 		};
 
 
@@ -703,6 +713,11 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			type: normalizedType,
 			categoryId: matchedCategory?.id,
 			paymentMethodId: finalPaymentMethodId,
+			manualDescription: manualDescription?.trim() || null,
+			locationName: locationName?.trim() || null,
+			latitude: Number.isFinite(Number(latitude)) ? Number(latitude) : null,
+			longitude: Number.isFinite(Number(longitude)) ? Number(longitude) : null,
+			googleMapsUrl: googleMapsUrl?.trim() || null,
 			reviewed: true,
 		});
 
@@ -719,6 +734,11 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			type,
 			source: 'manual',
 			referenceId: transaction.referenceId ?? undefined,
+			manualDescription: transaction.manualDescription ?? undefined,
+			locationName: transaction.locationName ?? undefined,
+			latitude: transaction.latitude === null ? undefined : Number(transaction.latitude),
+			longitude: transaction.longitude === null ? undefined : Number(transaction.longitude),
+			googleMapsUrl: transaction.googleMapsUrl ?? undefined,
 			reviewed: transaction.reviewed,
 		});
 	} catch (error) {
@@ -909,7 +929,21 @@ router.delete('/api/transactions/:id', requireAuth, async (req: Request, res: Re
 router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Response) => {
 	try {
 		const id = Number(req.params.id);
-		const { date, description, amount, currency, category, paymentMethodId, type, referenceId } = req.body as {
+		const {
+			date,
+			description,
+			amount,
+			currency,
+			category,
+			paymentMethodId,
+			type,
+			referenceId,
+			manualDescription,
+			locationName,
+			latitude,
+			longitude,
+			googleMapsUrl,
+		} = req.body as {
 			date?: string;
 			description?: string;
 			amount?: number;
@@ -918,6 +952,11 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			paymentMethodId?: number;
 			type?: 'income' | 'expense';
 			referenceId?: string;
+			manualDescription?: string;
+			locationName?: string;
+			latitude?: number | null;
+			longitude?: number | null;
+			googleMapsUrl?: string;
 		};
 
 		if (
@@ -965,6 +1004,9 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			}
 		}
 
+		const normalizedLatitude = Number.isFinite(Number(latitude)) ? Number(latitude) : null;
+		const normalizedLongitude = Number.isFinite(Number(longitude)) ? Number(longitude) : null;
+
 		const updated = await prisma.transaction.update({
 			where: { id: existingTransaction.id },
 			data: {
@@ -976,6 +1018,11 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 				paymentMethodId: resolvedPaymentMethodId,
 				type: type === 'income' ? 'credit' : 'debit',
 				referenceId: referenceId?.trim() || null,
+				manualDescription: manualDescription?.trim() || null,
+				locationName: locationName?.trim() || null,
+				latitude: normalizedLatitude,
+				longitude: normalizedLongitude,
+				googleMapsUrl: googleMapsUrl?.trim() || null,
 				reviewed: true,
 				reviewedAt: new Date(),
 			},
@@ -997,6 +1044,11 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			type: updated.type === 'credit' ? 'income' : 'expense',
 			source: 'manual',
 			referenceId: updated.referenceId ?? undefined,
+			manualDescription: updated.manualDescription ?? undefined,
+			locationName: updated.locationName ?? undefined,
+			latitude: updated.latitude === null ? undefined : Number(updated.latitude),
+			longitude: updated.longitude === null ? undefined : Number(updated.longitude),
+			googleMapsUrl: updated.googleMapsUrl ?? undefined,
 			currency: updated.currency,
 			reviewed: updated.reviewed,
 		});
@@ -1364,6 +1416,11 @@ router.patch('/api/transactions/:id/review', requireAuth, async (req: Request, r
 			type: updated.type === 'credit' ? 'income' : 'expense',
 			source: 'manual',
 			referenceId: updated.referenceId ?? undefined,
+			manualDescription: updated.manualDescription ?? undefined,
+			locationName: updated.locationName ?? undefined,
+			latitude: updated.latitude === null ? undefined : Number(updated.latitude),
+			longitude: updated.longitude === null ? undefined : Number(updated.longitude),
+			googleMapsUrl: updated.googleMapsUrl ?? undefined,
 			currency: updated.currency,
 			reviewed: updated.reviewed,
 		});
@@ -1386,6 +1443,11 @@ router.get('/api/budgets', requireAuth, async (req: Request, res: Response) => {
 				id: String(category.id),
 				category: category.name,
 				limit: Number(category.amountLimit ?? 0),
+				type: category.budgetType || 'spending',
+				targetAmount: category.targetAmount === null ? null : Number(category.targetAmount),
+				currentAmount: category.currentAmount === null ? null : Number(category.currentAmount),
+				dueDay: category.dueDay ?? null,
+				targetDate: category.targetDate ? category.targetDate.toISOString() : null,
 			}));
 
 		res.status(200).json(budgets);
@@ -1397,7 +1459,14 @@ router.get('/api/budgets', requireAuth, async (req: Request, res: Response) => {
 router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) => {
 	try {
 		const id = Number(req.params.id);
-		const { limit } = req.body as { limit?: number };
+		const { limit, type, targetAmount, currentAmount, dueDay, targetDate } = req.body as {
+			limit?: number;
+			type?: 'spending' | 'recurring' | 'goal' | 'reserve';
+			targetAmount?: number | null;
+			currentAmount?: number | null;
+			dueDay?: number | null;
+			targetDate?: string | null;
+		};
 
 		if (Number.isNaN(id) || limit === undefined) {
 			return res.status(400).json({ message: 'Invalid request' });
@@ -1411,15 +1480,31 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 			return res.status(404).json({ message: 'Category not found' });
 		}
 
+		const normalizedType = type && ['spending', 'recurring', 'goal', 'reserve'].includes(type) ? type : category.budgetType;
+		const normalizedDueDay = dueDay === null || dueDay === undefined ? dueDay : Number(dueDay);
+		const normalizedTargetDate = targetDate === null || targetDate === undefined || targetDate === '' ? null : new Date(targetDate);
+
 		const updated = await prisma.category.update({
 			where: { id: category.id },
-			data: { amountLimit: limit },
+			data: {
+				amountLimit: limit,
+				budgetType: normalizedType,
+				targetAmount: targetAmount === undefined ? category.targetAmount : targetAmount,
+				currentAmount: currentAmount === undefined ? category.currentAmount : currentAmount,
+				dueDay: normalizedDueDay === undefined ? category.dueDay : normalizedDueDay,
+				targetDate: targetDate === undefined ? category.targetDate : normalizedTargetDate,
+			},
 		});
 
 		res.status(200).json({
 			id: String(updated.id),
 			category: updated.name,
 			limit: Number(updated.amountLimit ?? 0),
+			type: updated.budgetType || 'spending',
+			targetAmount: updated.targetAmount === null ? null : Number(updated.targetAmount),
+			currentAmount: updated.currentAmount === null ? null : Number(updated.currentAmount),
+			dueDay: updated.dueDay ?? null,
+			targetDate: updated.targetDate ? updated.targetDate.toISOString() : null,
 		});
 	} catch (error) {
 		res.status(500).json({ message: 'Failed to update budget' });

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -33,6 +33,7 @@ import {
 	listSecurityPathBlocks,
 	removeSecurityPathBlock,
 } from '../src/lib/security-path-blocks';
+import { normalizeBudgetType, normalizeOptionalAmount, normalizeOptionalDueDay, normalizeOptionalTargetDate } from '../src/lib/budget-normalizers';
 
 const router = express.Router();
 const ignoredTransactionStatuses = new Set(['cancelled', 'canceled', 'declined', 'pending', 'reversed', 'void']);
@@ -1481,20 +1482,24 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 		}
 
 		const updateData: Prisma.CategoryUpdateInput = { amountLimit: limit };
-		if (type && ['spending', 'recurring', 'goal', 'reserve'].includes(type)) {
-			updateData.budgetType = type;
+		if (type !== undefined) {
+			updateData.budgetType = normalizeBudgetType(type);
 		}
-		if (targetAmount !== undefined) {
-			updateData.targetAmount = targetAmount;
+		const normalizedTargetAmount = normalizeOptionalAmount(targetAmount);
+		if (normalizedTargetAmount !== undefined) {
+			updateData.targetAmount = normalizedTargetAmount;
 		}
-		if (currentAmount !== undefined) {
-			updateData.currentAmount = currentAmount;
+		const normalizedCurrentAmount = normalizeOptionalAmount(currentAmount);
+		if (normalizedCurrentAmount !== undefined) {
+			updateData.currentAmount = normalizedCurrentAmount;
 		}
-		if (dueDay !== undefined) {
-			updateData.dueDay = dueDay === null ? null : Number(dueDay);
+		const normalizedDueDay = normalizeOptionalDueDay(dueDay);
+		if (normalizedDueDay !== undefined) {
+			updateData.dueDay = normalizedDueDay;
 		}
-		if (targetDate !== undefined) {
-			updateData.targetDate = targetDate === null || targetDate === '' ? null : new Date(targetDate);
+		const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
+		if (normalizedTargetDate !== undefined) {
+			updateData.targetDate = normalizedTargetDate;
 		}
 
 		const updated = await prisma.category.update({

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -1480,20 +1480,26 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 			return res.status(404).json({ message: 'Category not found' });
 		}
 
-		const normalizedType = type && ['spending', 'recurring', 'goal', 'reserve'].includes(type) ? type : category.budgetType;
-		const normalizedDueDay = dueDay === null || dueDay === undefined ? dueDay : Number(dueDay);
-		const normalizedTargetDate = targetDate === null || targetDate === undefined || targetDate === '' ? null : new Date(targetDate);
+		const updateData: Prisma.CategoryUpdateInput = { amountLimit: limit };
+		if (type && ['spending', 'recurring', 'goal', 'reserve'].includes(type)) {
+			updateData.budgetType = type;
+		}
+		if (targetAmount !== undefined) {
+			updateData.targetAmount = targetAmount;
+		}
+		if (currentAmount !== undefined) {
+			updateData.currentAmount = currentAmount;
+		}
+		if (dueDay !== undefined) {
+			updateData.dueDay = dueDay === null ? null : Number(dueDay);
+		}
+		if (targetDate !== undefined) {
+			updateData.targetDate = targetDate === null || targetDate === '' ? null : new Date(targetDate);
+		}
 
 		const updated = await prisma.category.update({
 			where: { id: category.id },
-			data: {
-				amountLimit: limit,
-				budgetType: normalizedType,
-				targetAmount: targetAmount === undefined ? category.targetAmount : targetAmount,
-				currentAmount: currentAmount === undefined ? category.currentAmount : currentAmount,
-				dueDay: normalizedDueDay === undefined ? category.dueDay : normalizedDueDay,
-				targetDate: targetDate === undefined ? category.targetDate : normalizedTargetDate,
-			},
+			data: updateData,
 		});
 
 		res.status(200).json({

--- a/src/lib/budget-normalizers.ts
+++ b/src/lib/budget-normalizers.ts
@@ -1,0 +1,29 @@
+export type BudgetType = 'spending' | 'recurring' | 'goal' | 'reserve';
+
+const BUDGET_TYPES = new Set<BudgetType>(['spending', 'recurring', 'goal', 'reserve']);
+
+export function normalizeBudgetType(value: unknown): BudgetType {
+	return typeof value === 'string' && BUDGET_TYPES.has(value as BudgetType) ? value as BudgetType : 'spending';
+}
+
+export function normalizeOptionalAmount(value: unknown): number | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || value === '') return null;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function normalizeOptionalDueDay(value: unknown): number | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || value === '') return null;
+	const parsed = Number(value);
+	return Number.isInteger(parsed) && parsed >= 1 && parsed <= 31 ? parsed : null;
+}
+
+export function normalizeOptionalTargetDate(value: unknown): Date | null | undefined {
+	if (value === undefined) return undefined;
+	if (value === null || value === '') return null;
+	if (typeof value !== 'string') return null;
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}

--- a/src/lib/receipt-image-storage.ts
+++ b/src/lib/receipt-image-storage.ts
@@ -188,14 +188,14 @@ export async function saveReceiptProcessingImage(params: {
 	publicSubdir?: 'receipt-processing' | 'receipt-review';
 }): Promise<StoredReceiptImage> {
 	const publicSubdir = params.publicSubdir || 'receipt-processing';
-	const receiptProcessingDir = path.resolve(process.cwd(), 'public', publicSubdir);
+	const receiptStorageDir = path.resolve(process.cwd(), 'public', publicSubdir);
 	const extension = getImageExtension(params.mimeType, params.originalName);
 	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 	const label = sanitizeLabel(params.label || 'scan');
 	const fileName = `${timestamp}-${label}-${params.requestId}${extension}`;
-	const filePath = path.join(receiptProcessingDir, fileName);
+	const filePath = path.join(receiptStorageDir, fileName);
 
-	await fs.mkdir(receiptProcessingDir, { recursive: true });
+	await fs.mkdir(receiptStorageDir, { recursive: true });
 	await fs.writeFile(filePath, params.buffer);
 
 	return {

--- a/src/lib/receipt-image-storage.ts
+++ b/src/lib/receipt-image-storage.ts
@@ -185,8 +185,10 @@ export async function saveReceiptProcessingImage(params: {
 	requestId: string;
 	baseUrl: string;
 	label?: string;
+	publicSubdir?: 'receipt-processing' | 'receipt-review';
 }): Promise<StoredReceiptImage> {
-	const receiptProcessingDir = path.resolve(process.cwd(), 'public', 'receipt-processing');
+	const publicSubdir = params.publicSubdir || 'receipt-processing';
+	const receiptProcessingDir = path.resolve(process.cwd(), 'public', publicSubdir);
 	const extension = getImageExtension(params.mimeType, params.originalName);
 	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 	const label = sanitizeLabel(params.label || 'scan');
@@ -199,7 +201,7 @@ export async function saveReceiptProcessingImage(params: {
 	return {
 		fileName,
 		filePath,
-		publicUrl: `${params.baseUrl}/receipt-processing/${fileName}`,
+		publicUrl: `${params.baseUrl}/${publicSubdir}/${fileName}`,
 	};
 }
 

--- a/tests/ai-assistant-controller.test.ts
+++ b/tests/ai-assistant-controller.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { Request, Response } from 'express';
-import { queueReceiptAnalysis } from '../controllers/ai-assistant/ai-assistant.controller';
+import { queueReceiptAnalysis, scanReceipt } from '../controllers/ai-assistant/ai-assistant.controller';
 import { ReceiptOcrQueueService } from '../modules/ai-assistant/receipt-ocr-queue.service';
+import { analyzeReceiptImageForUser } from '../modules/ai-assistant/receipt-analysis.service';
 import {
 	optimizeReceiptImageForOcr,
 	saveReceiptProcessingImage,
@@ -21,6 +22,10 @@ jest.mock('../modules/ai-assistant/receipt-ocr-queue.service', () => ({
 	},
 }));
 
+jest.mock('../modules/ai-assistant/receipt-analysis.service', () => ({
+	analyzeReceiptImageForUser: jest.fn(),
+}));
+
 jest.mock('../src/lib/receipt-image-storage', () => ({
 	getImageExtension: jest.fn(),
 	optimizeReceiptImageForOcr: jest.fn(),
@@ -35,6 +40,7 @@ jest.mock('../src/lib/sentry', () => ({
 const optimizeReceiptImageForOcrMock = jest.mocked(optimizeReceiptImageForOcr);
 const saveReceiptProcessingImageMock = jest.mocked(saveReceiptProcessingImage);
 const enqueueJobsMock = jest.mocked(ReceiptOcrQueueService.enqueueJobs);
+const analyzeReceiptImageForUserMock = jest.mocked(analyzeReceiptImageForUser);
 
 function createResponse() {
 	const json = jest.fn();
@@ -73,6 +79,23 @@ describe('AI Assistant Controller', () => {
 			filePath: `/tmp/${requestId}.jpg`,
 			fileName: `${requestId}.jpg`,
 		}));
+
+		analyzeReceiptImageForUserMock.mockResolvedValue({
+			date: '2026-04-06',
+			dateTime: '2026-04-06T00:00:00.000Z',
+			description: 'Receipt scan',
+			amount: 12.5,
+			category: 'Other',
+			type: 'expense',
+			currency: 'USD',
+			isDuplicate: false,
+			beloWithdrawMatch: null,
+			rawText: '',
+			textLines: [],
+			requiresManualReview: false,
+			parseWarning: null,
+			metadataDateTimeSuggestion: null,
+		});
 
 		enqueueJobsMock.mockResolvedValue([
 			{
@@ -142,4 +165,48 @@ describe('AI Assistant Controller', () => {
 			}),
 		]);
 	});
+
+	it('uses the default receipt-processing subdirectory for immediate receipt scans', async () => {
+		const req = {
+			user: {
+				id: 1,
+				firebaseId: 'firebase-user-1',
+				email: 'test@example.com',
+				createdAt: new Date('2026-04-06T00:00:00.000Z'),
+				dashboardBudgetPreferences: null,
+			},
+			body: {},
+			file: {
+				buffer: Buffer.from('scan-image'),
+				originalname: 'receipt.jpg',
+				mimetype: 'image/jpeg',
+				size: 5000,
+			},
+			get: (header: string) => {
+				if (header === 'host') return 'api.zentra-app.pro';
+				if (header === 'x-forwarded-proto') return 'https';
+				return undefined;
+			},
+			protocol: 'https',
+		} as unknown as Request;
+		const res = createResponse();
+
+		await scanReceipt(req, res);
+
+		expect(saveReceiptProcessingImageMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				label: 'scan',
+			})
+		);
+		expect(saveReceiptProcessingImageMock.mock.calls[0][0]).not.toHaveProperty('publicSubdir');
+		expect(analyzeReceiptImageForUserMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				imageInput: expect.objectContaining({
+					type: 'image-source',
+					value: 'https://api.zentra-app.pro/receipt-processing/req-123.jpg',
+				}),
+			})
+		);
+	});
+
 });

--- a/tests/ai-assistant-controller.test.ts
+++ b/tests/ai-assistant-controller.test.ts
@@ -128,6 +128,12 @@ describe('AI Assistant Controller', () => {
 
 		await queueReceiptAnalysis(req, res);
 
+		expect(saveReceiptProcessingImageMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				publicSubdir: 'receipt-review',
+				label: 'queue-1',
+			})
+		);
 		expect(enqueueJobsMock).toHaveBeenCalledTimes(1);
 		expect(enqueueJobsMock.mock.calls[0][1]).toEqual([
 			expect.objectContaining({

--- a/tests/budget-routes.test.ts
+++ b/tests/budget-routes.test.ts
@@ -55,10 +55,7 @@ describe('Budget Routes', () => {
 		});
 		expect(prismaMock.category.update).toHaveBeenCalledWith({
 			where: { id: category.id },
-			data: expect.objectContaining({
-				amountLimit: 350,
-				budgetType: 'spending',
-			}),
+			data: { amountLimit: 350 },
 		});
 	});
 

--- a/tests/budget-routes.test.ts
+++ b/tests/budget-routes.test.ts
@@ -44,13 +44,21 @@ describe('Budget Routes', () => {
 			id: String(updatedCategory.id),
 			category: updatedCategory.name,
 			limit: 350,
+			type: 'spending',
+			targetAmount: null,
+			currentAmount: null,
+			dueDay: null,
+			targetDate: null,
 		});
 		expect(prismaMock.category.findFirst).toHaveBeenCalledWith({
 			where: { id: 10, userId: 1 },
 		});
 		expect(prismaMock.category.update).toHaveBeenCalledWith({
 			where: { id: category.id },
-			data: { amountLimit: 350 },
+			data: expect.objectContaining({
+				amountLimit: 350,
+				budgetType: 'spending',
+			}),
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add typed budget metadata for spending, recurring, goal, and reserve budgets
- Add goal fields: target amount, current amount, due day, and target date
- Persist manual transaction description/location fields and store AI review receipt images under receipt-review

## Validation
- npx prisma generate
- npx eslint controllers/categories.controller.ts routes/router.ts controllers/ai-assistant/ai-assistant.controller.ts src/lib/receipt-image-storage.ts tests/ai-assistant-controller.test.ts
- npx jest tests/ai-assistant-controller.test.ts modules/budgets/budget-rollover.service.test.ts --runInBand --watchman=false --coverage=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction tracking with support for location details (name, coordinates, Maps URL) and manual descriptions.
  * Expanded budget management enabling budget type categorization, target amounts, current tracking, due dates, and target dates for more granular financial planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->