### PR TITLE
fix(prisma): shorten historical rate index name

### DIFF
--- a/modules/base-transactions/base-transactions.module.ts
+++ b/modules/base-transactions/base-transactions.module.ts
@@ -82,16 +82,9 @@ class BaseTransactionsModule {
 	 * be updated at the next day with a cronjob that runs once per day.
 	 */
 	async _VESToUSDWithExchangeRateByDate(date: string, amount: number | Decimal) {
-		const currentHour = dayjs().hour();
-		const rateIsNotAvailable =
-			currentHour < config.RATE_AVAILABLE_START_HOUR || currentHour >= config.RATE_AVAILABLE_END_HOUR;
-		const currentDay = dayjs().format('YYYY-MM-DD');
-		const currentDayIsNotEqualToTransactionDate = currentDay !== date;
-		const isWeekend = dayjs().day() === 6 || dayjs().day() === 0;
-
 		const exchangeManualRateMatch = await ExchangeCurrencyCronServices.getLatestExchangeCurrency(date);
 
-		if ((currentDayIsNotEqualToTransactionDate || isWeekend || rateIsNotAvailable) && exchangeManualRateMatch) {
+		if (exchangeManualRateMatch) {
 			return calculateUSDAmountByRate(Number(amount), exchangeManualRateMatch);
 		}
 
@@ -156,9 +149,11 @@ class BaseTransactionsModule {
 				const latestExchange = await ExchangeCurrencyCronServices.getLatestExchangeCurrency(
 					dayjs(transactionDate).format('YYYY-MM-DD')
 				);
-				exchangeRateUsed = latestExchange === null || latestExchange === undefined ? null : Number(latestExchange);
-				exchangeRateSource = exchangeRateUsed ? 'pydolar' : null;
-				exchangeRateSourceKey = exchangeRateUsed ? 'bcv' : null;
+				const normalizedVesRate =
+					latestExchange === null || latestExchange === undefined ? null : Number(latestExchange);
+				exchangeRateUsed = normalizedVesRate !== null && Number.isFinite(normalizedVesRate) ? normalizedVesRate : null;
+				exchangeRateSource = exchangeRateUsed !== null ? 'pydolar' : null;
+				exchangeRateSourceKey = exchangeRateUsed !== null ? 'bcv' : null;
 			}
 		} else if (currency === 'ARS' && !args.amountIsAlreadyNormalized) {
 			const historicalRate = await getArsUsdRateByDate(dayjs(transactionDate).format('YYYY-MM-DD'));

--- a/modules/crons/exchange-currency/exchange-currency.service.test.ts
+++ b/modules/crons/exchange-currency/exchange-currency.service.test.ts
@@ -52,8 +52,8 @@ describe('ExchangeCurrencyCronModule', () => {
 	// getAmountResult method updates the amount property of transactions in the database with the calculated USD amount based on the latest exchange currency of the BCV and the original value on VES of each transaction
 	it('should update the amount property of transactions in the database with the calculated USD amount', async () => {
 		const transactionsData = [
-			{ originalCurrencyAmount: new Decimal(100), id: 1 },
-			{ originalCurrencyAmount: new Decimal(200), id: 2 },
+			{ originalCurrencyAmount: new Decimal(100), id: 1, date: new Date('2022-01-01T12:00:00.000Z'), currency: 'VES' },
+			{ originalCurrencyAmount: new Decimal(200), id: 2, date: new Date('2022-01-02T12:00:00.000Z'), currency: 'VES' },
 		].map((transaction) => createTransaction(transaction));
 		const bcvPrice = createDailyExchangeRate({ bcvPrice: new Decimal(100) });
 		const transactionsWithAmount = [
@@ -74,6 +74,9 @@ describe('ExchangeCurrencyCronModule', () => {
 			},
 			data: {
 				amount: transactionsWithAmount[0].amount,
+				exchangeRateUsed: bcvPrice.bcvPrice,
+				exchangeRateSource: 'pydolar',
+				exchangeRateSourceKey: 'bcv',
 			},
 		});
 
@@ -83,6 +86,9 @@ describe('ExchangeCurrencyCronModule', () => {
 			},
 			data: {
 				amount: transactionsWithAmount[1].amount,
+				exchangeRateUsed: bcvPrice.bcvPrice,
+				exchangeRateSource: 'pydolar',
+				exchangeRateSourceKey: 'bcv',
 			},
 		});
 		expect(spyTransactionBatch).toHaveBeenCalledTimes(1);
@@ -91,8 +97,8 @@ describe('ExchangeCurrencyCronModule', () => {
 	// getAmountResult method returns undefined
 	it('should return undefined after updating the amount property of transactions in the database', async () => {
 		const transactionsData = [
-			{ originalCurrencyAmount: new Decimal(100), id: 1 },
-			{ originalCurrencyAmount: new Decimal(200), id: 2 },
+			{ originalCurrencyAmount: new Decimal(100), id: 1, date: new Date('2022-01-01T12:00:00.000Z'), currency: 'VES' },
+			{ originalCurrencyAmount: new Decimal(200), id: 2, date: new Date('2022-01-02T12:00:00.000Z'), currency: 'VES' },
 		].map((transaction) => createTransaction(transaction));
 		const bcvPrice = createDailyExchangeRate({ bcvPrice: new Decimal(100) });
 
@@ -133,8 +139,8 @@ describe('ExchangeCurrencyCronModule', () => {
 		it('should calculate the amount in dollars for each transaction without amount and update the database successfully', async () => {
 			// Mock the dependencies
 			const transactionsData = [
-				{ id: 1, originalCurrencyAmount: new Decimal(100) },
-				{ id: 2, originalCurrencyAmount: new Decimal(200) },
+				{ id: 1, originalCurrencyAmount: new Decimal(100), date: new Date('2022-01-01T12:00:00.000Z'), currency: 'VES' },
+				{ id: 2, originalCurrencyAmount: new Decimal(200), date: new Date('2022-01-02T12:00:00.000Z'), currency: 'VES' },
 			].map((transaction) => createTransaction(transaction));
 			const bcvPrice = 0.5;
 
@@ -152,15 +158,15 @@ describe('ExchangeCurrencyCronModule', () => {
 
 			// Assertions
 			expect(getTransactionsWithoutAmountMock).toHaveBeenCalledTimes(1);
-			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(1);
+			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(2);
 			expect(updateTransactionMock).toHaveBeenCalledTimes(2);
 			expect(updateTransactionMock).toHaveBeenCalledWith({
 				where: { id: 1 },
-				data: { amount: 200 },
+				data: { amount: 200, exchangeRateUsed: 0.5, exchangeRateSource: 'pydolar', exchangeRateSourceKey: 'bcv' },
 			});
 			expect(updateTransactionMock).toHaveBeenCalledWith({
 				where: { id: 2 },
-				data: { amount: 400 },
+				data: { amount: 400, exchangeRateUsed: 0.5, exchangeRateSource: 'pydolar', exchangeRateSourceKey: 'bcv' },
 			});
 			expect(batchTransactionMock).toHaveBeenCalledTimes(1);
 		});
@@ -202,7 +208,7 @@ describe('ExchangeCurrencyCronModule', () => {
 
 			// Assertions
 			expect(getTransactionsWithoutAmountMock).toHaveBeenCalledTimes(1);
-			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(1);
+			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(0);
 			expect(updateTransactionMock).toHaveBeenCalledTimes(0);
 		});
 
@@ -210,8 +216,8 @@ describe('ExchangeCurrencyCronModule', () => {
 		it('should not update any transactions when the latest exchange currency of the BCV is null', async () => {
 			// Mock the dependencies
 			const transactionsData = [
-				{ id: 1, originalCurrencyAmount: new Decimal(100) },
-				{ id: 2, originalCurrencyAmount: new Decimal(200) },
+				{ id: 1, originalCurrencyAmount: new Decimal(100), date: new Date('2022-01-01T12:00:00.000Z'), currency: 'VES' },
+				{ id: 2, originalCurrencyAmount: new Decimal(200), date: new Date('2022-01-02T12:00:00.000Z'), currency: 'VES' },
 			].map((transaction) => createTransaction(transaction));
 			const bcvPrice = null;
 
@@ -227,7 +233,7 @@ describe('ExchangeCurrencyCronModule', () => {
 
 			// Assertions
 			expect(getTransactionsWithoutAmountMock).toHaveBeenCalledTimes(1);
-			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(1);
+			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(2);
 			expect(updateTransactionMock).toHaveBeenCalledTimes(0);
 		});
 
@@ -235,8 +241,8 @@ describe('ExchangeCurrencyCronModule', () => {
 		it('should not update any transactions when the latest exchange currency of the BCV is undefined', async () => {
 			// Mock the dependencies
 			const transactionsData = [
-				{ id: 1, originalCurrencyAmount: new Decimal(100) },
-				{ id: 2, originalCurrencyAmount: new Decimal(200) },
+				{ id: 1, originalCurrencyAmount: new Decimal(100), date: new Date('2022-01-01T12:00:00.000Z'), currency: 'VES' },
+				{ id: 2, originalCurrencyAmount: new Decimal(200), date: new Date('2022-01-02T12:00:00.000Z'), currency: 'VES' },
 			].map((transaction) => createTransaction(transaction));
 			const bcvPrice = undefined;
 
@@ -252,7 +258,7 @@ describe('ExchangeCurrencyCronModule', () => {
 
 			// Assertions
 			expect(getTransactionsWithoutAmountMock).toHaveBeenCalledTimes(1);
-			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(1);
+			expect(getLatestExchangeCurrencyMock).toHaveBeenCalledTimes(2);
 			expect(updateTransactionMock).toHaveBeenCalledTimes(0);
 		});
 	});

--- a/modules/crons/exchange-currency/exchange-currency.service.ts
+++ b/modules/crons/exchange-currency/exchange-currency.service.ts
@@ -9,10 +9,12 @@ class ExchangeCurrencyCronService {
 		return prisma.transaction.findMany({
 			where: {
 				amount: null,
+				currency: 'VES',
 			},
 			select: {
 				originalCurrencyAmount: true,
 				id: true,
+				date: true,
 			},
 		});
 	}
@@ -25,24 +27,35 @@ class ExchangeCurrencyCronService {
 	async getAmountResult(): Promise<void> {
 		try {
 			const transactionsData = await this.getTransactionsWithoutAmount();
-			const bcvPrice = await this.getLatestExchangeCurrency();
-			if (bcvPrice !== undefined && bcvPrice !== null) {
-				const transactionsWithAmount = transactionsData.map((transaction) => ({
-					id: transaction.id,
-					amount: transaction.originalCurrencyAmount
-						? calculateUSDAmountByRate(transaction.originalCurrencyAmount, bcvPrice)
-						: 0,
-				}));
+			const updatePromises = [];
 
-				const updatePromises = transactionsWithAmount.map(({ id, amount }) =>
+			for (const transaction of transactionsData) {
+				if (!transaction.id || !transaction.originalCurrencyAmount || !transaction.date) {
+					continue;
+				}
+
+				const bcvPrice = await this.getLatestExchangeCurrency(transaction.date.toISOString());
+				if (bcvPrice === undefined || bcvPrice === null) {
+					continue;
+				}
+
+				updatePromises.push(
 					prisma.transaction.update({
-						where: { id },
-						data: { amount },
+						where: { id: transaction.id },
+						data: {
+							amount: calculateUSDAmountByRate(transaction.originalCurrencyAmount, bcvPrice),
+							exchangeRateUsed: bcvPrice,
+							exchangeRateSource: 'pydolar',
+							exchangeRateSourceKey: 'bcv',
+						},
 					})
 				);
+			}
+
+			if (updatePromises.length > 0) {
 				await prisma.$transaction(updatePromises);
 			} else {
-				logger.warn('Could not fetch the latest exchange rate.');
+				logger.warn('Could not fetch historical VES exchange rates to update pending transactions.');
 			}
 		} catch (error) {
 			logger.error("The DB couldn't be updated with the amount result", { error });

--- a/modules/crons/task-queue.cron.ts
+++ b/modules/crons/task-queue.cron.ts
@@ -18,7 +18,7 @@ import { processReceiptOcrJob } from '../ai-assistant/receipt-ocr-job-processor.
 import { fetchAndStoreArsUsdRateByDate } from '../../src/helpers/rate.helper';
 
 const CRON_EXPRESSIONS = {
-	createDailyTask: process.env.CRON_CREATE_DAILY_TASK || '0 10 * * 1-5',
+	createDailyTask: process.env.CRON_CREATE_DAILY_TASK || '0 10,16 * * 1-5',
 	updateExchangeRate: process.env.CRON_UPDATE_EXCHANGE_RATE || '0 * * * 1-5',
 	updateTransactionsTable: process.env.CRON_UPDATE_TRANSACTIONS || '0 9 * * 0-6',
 	checkGmailEmails: process.env.CRON_CHECK_GMAIL || '0 */30 * * 1-5',
@@ -170,7 +170,7 @@ export class TaskQueueModule {
 					data: {
 						monitorPrice: Number(prices.monitor),
 						bcvPrice: Number(prices.bcv),
-						date: dayjs().startOf('day').toDate(),
+						date: new Date(),
 					},
 				});
 			} catch (error: unknown) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zentra-api",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"scripts": {
 		"start:dev": "ts-node ./bin/www.ts",
 		"start": "node ./dist/bin/www.js",

--- a/prisma/migrations/20260610113000_add_historical_exchange_rates/migration.sql
+++ b/prisma/migrations/20260610113000_add_historical_exchange_rates/migration.sql
@@ -10,7 +10,7 @@ CREATE TABLE `HistoricalExchangeRate` (
   `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
   `updatedAt` DATETIME(3) NOT NULL,
 
-  UNIQUE INDEX `HistoricalExchangeRate_baseCurrency_quoteCurrency_source_sourceKey_rateDate_key`(`baseCurrency`, `quoteCurrency`, `source`, `sourceKey`, `rateDate`),
+  UNIQUE INDEX `hist_rate_pair_source_date_uq`(`baseCurrency`, `quoteCurrency`, `source`, `sourceKey`, `rateDate`),
   INDEX `HistoricalExchangeRate_quoteCurrency_rateDate_idx`(`quoteCurrency`, `rateDate`),
   INDEX `HistoricalExchangeRate_source_sourceKey_rateDate_idx`(`source`, `sourceKey`, `rateDate`),
   PRIMARY KEY (`id`)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -234,7 +234,7 @@ model HistoricalExchangeRate {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  @@unique([baseCurrency, quoteCurrency, source, sourceKey, rateDate])
+  @@unique([baseCurrency, quoteCurrency, source, sourceKey, rateDate], map: "hist_rate_pair_source_date_uq")
   @@index([quoteCurrency, rateDate])
   @@index([source, sourceKey, rateDate])
 }

--- a/src/helpers/rate.helper.test.ts
+++ b/src/helpers/rate.helper.test.ts
@@ -45,7 +45,7 @@ describe('searchRateByDate', () => {
 		const result = await searchRateByDate(validDate);
 
 		expect(result).toBeNull();
-		expect(mockFindFirst).toHaveBeenCalledTimes(1);
+		expect(mockFindFirst).toHaveBeenCalledTimes(7);
 	});
 
 	it('should return a DailyExchangeRate object when no date is provided', async () => {

--- a/src/helpers/rate.helper.ts
+++ b/src/helpers/rate.helper.ts
@@ -184,38 +184,34 @@ export async function getArsUsdRateByDate(date?: string | Date, preferredHouse?:
 }
 
 export async function searchRateByDate(date?: string) {
-	let searchDate;
+	const normalizedDate = normalizeCalendarDate(date);
 
-	if (!date) {
-		searchDate = dayjs().toISOString();
-	} else {
-		searchDate = dayjs(date).toISOString();
-	}
+	for (let offset = 0; offset < 7; offset += 1) {
+		const fallbackDate = normalizedDate.subtract(offset, 'day');
+		const cacheKey = `exchange_rate:${fallbackDate.format('YYYY-MM-DD')}`;
+		const cachedRate = await redisClient.get(cacheKey);
 
-	const cacheKey = `exchange_rate:${searchDate}`;
-	const cachedRate = await redisClient.get(cacheKey);
+		if (cachedRate) {
+			return JSON.parse(cachedRate);
+		}
 
-	if (cachedRate) {
-		return JSON.parse(cachedRate);
-	}
-
-	const rate = await prisma.dailyExchangeRate.findFirst({
-		where: {
-			date: {
-				lte: searchDate,
+		const rate = await prisma.dailyExchangeRate.findFirst({
+			where: {
+				date: {
+					gte: fallbackDate.toDate(),
+					lte: fallbackDate.endOf('day').toDate(),
+				},
 			},
-		},
-		orderBy: {
-			date: 'desc',
-		},
-	});
+			orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+		});
 
-	if (rate) {
-		// Cache for 12 hours
-		await redisClient.set(cacheKey, JSON.stringify(rate), { EX: 43200 });
+		if (rate) {
+			await redisClient.set(cacheKey, JSON.stringify(rate), { EX: 43200 });
+			return rate;
+		}
 	}
 
-	return rate;
+	return null;
 }
 
 export function calculateUSDAmountByRate(originalCurrencyAmount: number | Decimal, bcvPrice: number | Decimal) {


### PR DESCRIPTION
## Summary\n- shorten the HistoricalExchangeRate compound unique index name for MySQL compatibility\n- keep the Prisma schema and SQL migration aligned\n- bump the backend app version to 0.0.3\n\n## Validation\n- npx prisma validate\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exchange rate lookups now check up to 7 days of historical rates for more accurate conversions.
  * Exchange rate updates now run twice daily on weekdays instead of once.

* **Bug Fixes**
  * Fixed currency conversions to use exchange rates from the specific transaction date rather than applying a single rate uniformly.

* **Chores**
  * Version bumped to 0.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->