### PR TITLE
feat(cash-lots): allocate withdrawals and cash expenses

### DIFF
--- a/docs/cash-lots.md
+++ b/docs/cash-lots.md
@@ -1,0 +1,89 @@
+# Cash Lots
+
+## Overview
+
+Cash Lots track cash obtained from ATM withdrawals and link later cash expenses to the specific withdrawal(s) that funded them.
+
+Withdrawals are no longer treated as spending. Instead, each withdrawal creates a lot that behaves like a temporary cash inventory with a remaining balance.
+
+## Data Model
+
+### CashLot
+
+- `id`
+- `withdrawalTransactionId`
+- `sourceAmount`
+- `sourceCurrency`
+- `destinationAmount`
+- `destinationCurrency`
+- `exchangeRate`
+- `remainingAmount`
+- `migrationStatus`
+- `createdAt`
+- `updatedAt`
+
+### CashLotAllocation
+
+- `id`
+- `cashLotId`
+- `expenseTransactionId`
+- `allocatedAmount`
+- `exchangeRate`
+- `createdAt`
+
+## Allocation Logic
+
+1. An ATM withdrawal creates a `CashLot`.
+2. Cash expenses consume available lots in FIFO order.
+3. A cash expense can allocate from multiple lots if needed.
+4. Each allocation stores the exact amount consumed and the exchange rate used for that lot.
+5. Remaining cash is updated on the affected lot(s).
+
+For each allocation:
+
+```ts
+sourceEquivalent = allocatedAmount / exchangeRate
+```
+
+## Examples
+
+### Withdrawal
+
+```ts
+100 USD -> 120000 ARS @ 1200
+```
+
+Creates:
+
+```ts
+CashLot {
+  sourceAmount: 100,
+  sourceCurrency: 'USD',
+  destinationAmount: 120000,
+  destinationCurrency: 'ARS',
+  exchangeRate: 1200,
+  remainingAmount: 120000
+}
+```
+
+### Cash Expense
+
+If the user spends `20000 ARS`, the system consumes from the oldest available ARS cash lot(s), stores allocation records, and reduces the lot remaining amount.
+
+## Edge Cases
+
+- **Multiple withdrawals in the same currency**: handled with FIFO ordering.
+- **Partial consumption**: the lot remains available with a reduced `remainingAmount`.
+- **Full consumption**: the lot balance reaches zero and remains linked for history.
+- **Expense larger than one lot**: allocates across multiple lots.
+- **Cash refunds**: should be recorded as a cash inflow transaction and re-linked manually if needed.
+- **Cash transaction edits**: allocation records are restored and recalculated.
+- **Cash transaction deletion**: allocation records are restored to their source lots.
+- **Withdrawal deletion**: blocked when the withdrawal has already funded cash expenses.
+- **Insufficient cash balance**: the transaction is rejected until enough cash lots exist.
+
+## Historical Migration
+
+Historical withdrawals are converted into cash lots where the source and destination amounts can be inferred from existing transaction data.
+
+If a withdrawal cannot be linked safely, it is imported as `unlinked` and excluded from automatic allocation.

--- a/docs/cash-lots.md
+++ b/docs/cash-lots.md
@@ -10,26 +10,33 @@ Withdrawals are no longer treated as spending. Instead, each withdrawal creates 
 
 ### CashLot
 
-- `id`
-- `withdrawalTransactionId`
-- `sourceAmount`
-- `sourceCurrency`
-- `destinationAmount`
-- `destinationCurrency`
-- `exchangeRate`
-- `remainingAmount`
-- `migrationStatus`
-- `createdAt`
-- `updatedAt`
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `number` | Unique identifier for the cash lot. |
+| `userId` | `number` | Tenant identifier for multi-tenant isolation. |
+| `withdrawalTransactionId` | `number \| null` | Linked withdrawal transaction. |
+| `withdrawalDate` | `ISO8601 timestamp` | Date used for FIFO ordering. |
+| `sourceAmount` | `number` | Original source currency amount withdrawn from the account. |
+| `sourceCurrency` | `string` | Source currency code, usually the account currency. |
+| `destinationAmount` | `number` | Cash amount received in the destination currency. |
+| `destinationCurrency` | `string` | Destination currency code for the cash lot. |
+| `exchangeRate` | `number` | Exchange rate applied when the lot was created. |
+| `remainingAmount` | `number` | Unused destination currency still available in the lot. |
+| `migrationStatus` | `linked \| unlinked` | `linked` means the withdrawal was safely associated with a lot and can be used in automatic allocation. `unlinked` means the record could not be safely associated, so it is excluded from automatic allocation and downstream cash consumption. |
+| `createdAt` | `ISO8601 timestamp` | Timestamp when the lot was created. |
+| `updatedAt` | `ISO8601 timestamp` | Timestamp when the lot was last updated. |
 
 ### CashLotAllocation
 
-- `id`
-- `cashLotId`
-- `expenseTransactionId`
-- `allocatedAmount`
-- `exchangeRate`
-- `createdAt`
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `number` | Unique identifier for the allocation record. |
+| `userId` | `number` | Tenant identifier for multi-tenant isolation. |
+| `cashLotId` | `number` | Foreign key to the cash lot that funded the expense. |
+| `expenseTransactionId` | `number` | Linked expense transaction. |
+| `allocatedAmount` | `number` | Amount of destination currency consumed from the lot. |
+| `exchangeRate` | `number` | Exchange rate applied at allocation time. |
+| `createdAt` | `ISO8601 timestamp` | Timestamp when the allocation was created. |
 
 ## Allocation Logic
 
@@ -76,9 +83,9 @@ If the user spends `20000 ARS`, the system consumes from the oldest available AR
 - **Partial consumption**: the lot remains available with a reduced `remainingAmount`.
 - **Full consumption**: the lot balance reaches zero and remains linked for history.
 - **Expense larger than one lot**: allocates across multiple lots.
-- **Cash refunds**: should be recorded as a cash inflow transaction and re-linked manually if needed.
-- **Cash transaction edits**: allocation records are restored and recalculated.
-- **Cash transaction deletion**: allocation records are restored to their source lots.
+- **Cash refunds**: record the refund as a cash inflow transaction and relink manually if needed.
+- **When editing a cash transaction**: restore the previous allocation records and recalculate them from the updated expense.
+- **On deletion of a cash transaction**: restore allocation records to their source lots before removing the transaction.
 - **Withdrawal deletion**: blocked when the withdrawal has already funded cash expenses.
 - **Insufficient cash balance**: the transaction is rejected until enough cash lots exist.
 

--- a/docs/updates/cash-lots.md
+++ b/docs/updates/cash-lots.md
@@ -1,0 +1,35 @@
+# Cash Lots Update
+
+## What changed
+
+- ATM withdrawals now create cash lots.
+- Cash expenses consume available cash lots instead of acting as standalone balances.
+- The app now stores allocation breakdowns for cash spending.
+- Withdrawal and cash expense screens show lot balance, rate, and linked transactions.
+
+## Why withdrawals are no longer expenses
+
+Withdrawals move money from an account into a cash wallet. The spending happens later, when the cash is used.
+
+## How cash is now tracked
+
+- Every withdrawal creates a lot with:
+  - source amount
+  - destination cash amount
+  - exchange rate
+  - remaining amount
+- Every cash expense consumes one or more lots using FIFO.
+- Each consumption is stored as an allocation record.
+
+## How exchange rates are applied
+
+- The withdrawal saves the exchange rate used at the moment of withdrawal.
+- Cash expenses inherit the exchange rate from the lot(s) they consume.
+- The app preserves the source-currency equivalent for each allocation.
+
+## What users need to know
+
+- Mark ATM operations as **cash withdrawals**.
+- Enter the cash amount received and the exchange rate.
+- Enter cash expenses normally so the system can consume the right lots.
+- If a cash expense is edited or deleted, the linked lots are restored automatically.

--- a/modules/base-transactions/base-transactions.module.ts
+++ b/modules/base-transactions/base-transactions.module.ts
@@ -22,6 +22,8 @@ type TransactionWithOptionalRelations = Transaction & {
 	paymentMethod: PaymentMethod | null;
 };
 
+type PrismaLikeClient = PrismaClient | Prisma.TransactionClient;
+
 type SafeCreateTransactionInput = Prisma.TransactionUncheckedCreateInput & {
 	userId: number;
 	amount: number | Decimal;
@@ -396,13 +398,13 @@ class BaseTransactionsModule {
 		return candidates.find((candidate) => this.isDuplicateCandidate(data, candidate)) ?? null;
 	}
 
-	async findDuplicate(data: DuplicateLookupInput): Promise<TransactionWithRelations | null> {
+	async findDuplicate(data: DuplicateLookupInput, db: PrismaLikeClient = this._db): Promise<TransactionWithRelations | null> {
 		const { userId, amount, date, type, currency, referenceId } = data;
 		const normalizedAmount = amount instanceof Decimal ? amount : new Decimal(amount);
 
 		// 1. Priority: Exact referenceId match
 		if (referenceId) {
-			const refMatch = await this._db.transaction.findFirst({
+			const refMatch = await db.transaction.findFirst({
 				where: {
 					userId,
 					referenceId,
@@ -419,7 +421,7 @@ class BaseTransactionsModule {
 		const startDate = dayjs(date).subtract(1, 'day').toDate();
 		const endDate = dayjs(date).add(1, 'day').toDate();
 
-		const potentialDuplicates = (await this._db.transaction.findMany({
+		const potentialDuplicates = (await db.transaction.findMany({
 			where: {
 				userId,
 				amount: normalizedAmount,
@@ -445,7 +447,7 @@ class BaseTransactionsModule {
 	 * Creates a transaction only if it's not a duplicate.
 	 * Handles internal VES -> USD normalization if needed.
 	 */
-	async safeCreateTransaction(data: SafeCreateTransactionInput): Promise<SafeCreateTransactionResult> {
+	async safeCreateTransaction(data: SafeCreateTransactionInput, db: PrismaLikeClient = this._db): Promise<SafeCreateTransactionResult> {
 		const { amount, currency, date } = data;
 		const transactionDate = date instanceof Date ? date : new Date(date);
 		const normalizedAmounts = await this.normalizeTransactionAmount({
@@ -469,7 +471,7 @@ class BaseTransactionsModule {
 				currency: normalizedCurrency || 'USD',
 				description: data.description ?? undefined,
 				referenceId: data.referenceId ?? undefined,
-			});
+			}, db);
 
 			if (duplicate) {
 				logger.info('Duplicate transaction detected, skipping creation', {
@@ -484,7 +486,7 @@ class BaseTransactionsModule {
 		}
 
 		const { amountIsAlreadyNormalized: _amountIsAlreadyNormalized, skipDuplicateCheck: _skipDuplicateCheck, ...transactionData } = data;
-		const transaction = await this._db.transaction.create({
+		const transaction = await db.transaction.create({
 			data: {
 				...transactionData,
 				date: transactionDate,

--- a/modules/budgets/budget-rollover.service.test.ts
+++ b/modules/budgets/budget-rollover.service.test.ts
@@ -17,6 +17,7 @@ describe('BudgetRolloverService', () => {
 			// Mock category limit
 			prismaMock.category.findUnique.mockResolvedValue({
 				id: categoryId,
+				userId: 1,
 				amountLimit: new Decimal(100),
 				isCumulative: true,
 			} as any);
@@ -31,7 +32,7 @@ describe('BudgetRolloverService', () => {
 				_sum: { amount: new Decimal(80) },
 			} as any);
 
-			const carryOver = await BudgetRollover.calculateRollover(categoryId, targetMonth, targetYear);
+			const carryOver = await BudgetRollover.calculateRollover(categoryId, 1, targetMonth, targetYear);
 
 			// March: $100 limit - $80 spent = $20 carryOver for April
 			expect(carryOver).toBe(20);
@@ -63,7 +64,7 @@ describe('BudgetRolloverService', () => {
 				.mockResolvedValueOnce({ _sum: { amount: new Decimal(40) } } as any)
 				.mockResolvedValueOnce({ _sum: { amount: new Decimal(50) } } as any);
 
-			const carryOver = await BudgetRollover.calculateRollover(categoryId, 6, targetYear);
+			const carryOver = await BudgetRollover.calculateRollover(categoryId, 1, 6, targetYear);
 
 			expect(carryOver).toBe(130);
 		});
@@ -71,6 +72,7 @@ describe('BudgetRolloverService', () => {
 		it('should include previous carry-over in calculation', async () => {
 			prismaMock.category.findUnique.mockResolvedValue({
 				id: categoryId,
+				userId: 1,
 				amountLimit: new Decimal(100),
 				isCumulative: true,
 			} as any);
@@ -85,7 +87,7 @@ describe('BudgetRolloverService', () => {
 				_sum: { amount: new Decimal(120) },
 			} as any);
 
-			const carryOver = await BudgetRollover.calculateRollover(categoryId, targetMonth, targetYear);
+			const carryOver = await BudgetRollover.calculateRollover(categoryId, 1, targetMonth, targetYear);
 
 			// March: ($100 limit + $50 carryOver) - $120 spent = $30 carryOver for April
 			expect(carryOver).toBe(30);
@@ -94,6 +96,7 @@ describe('BudgetRolloverService', () => {
 		it('should return 0 if there was a deficit (no negative carry-over)', async () => {
 			prismaMock.category.findUnique.mockResolvedValue({
 				id: categoryId,
+				userId: 1,
 				amountLimit: new Decimal(100),
 			} as any);
 
@@ -106,7 +109,7 @@ describe('BudgetRolloverService', () => {
 				_sum: { amount: new Decimal(110) },
 			} as any);
 
-			const carryOver = await BudgetRollover.calculateRollover(categoryId, targetMonth, targetYear);
+			const carryOver = await BudgetRollover.calculateRollover(categoryId, 1, targetMonth, targetYear);
 
 			expect(carryOver).toBe(0);
 		});
@@ -149,7 +152,7 @@ describe('BudgetRolloverService', () => {
 				.mockResolvedValueOnce({ _sum: { amount: new Decimal(70) } } as any)
 				.mockResolvedValueOnce({ _sum: { amount: new Decimal(25) } } as any);
 
-			const carryOver = await BudgetRollover.calculateRollover(targetCategoryId, targetMonth, targetYear);
+			const carryOver = await BudgetRollover.calculateRollover(targetCategoryId, 1, targetMonth, targetYear);
 
 			expect(carryOver).toBe(65);
 		});
@@ -170,7 +173,7 @@ describe('BudgetRolloverService', () => {
 
 		it('should create a new period with carry-over if it does not exist', async () => {
 			prismaMock.budgetPeriod.findUnique.mockResolvedValue(null); // First call: check existing
-			prismaMock.category.findUnique.mockResolvedValue({ id: categoryId, isCumulative: true, amountLimit: new Decimal(100), name: 'Pets' } as any);
+			prismaMock.category.findUnique.mockResolvedValue({ id: categoryId, userId: 1, isCumulative: true, amountLimit: new Decimal(100), name: 'Pets' } as any);
 			
 			// Mock rollover calculation (March to April)
 			prismaMock.budgetPeriod.findUnique.mockResolvedValueOnce(null) // JIT check
@@ -202,8 +205,8 @@ describe('BudgetRolloverService', () => {
 				] as any);
 
 			prismaMock.category.findMany.mockResolvedValue([
-				{ id: 10, isCumulative: true },
-				{ id: 11, isCumulative: false },
+				{ id: 10, userId: 1, isCumulative: true },
+				{ id: 11, userId: 1, isCumulative: false },
 			] as any);
 
 			prismaMock.transaction.aggregate.mockResolvedValue({ _sum: { amount: new Decimal(75) } } as any);

--- a/modules/budgets/budget-rollover.service.ts
+++ b/modules/budgets/budget-rollover.service.ts
@@ -48,7 +48,7 @@ export class BudgetRolloverService {
 		// 3. Create rollover from previous month if cumulative
 		let carryOver = 0;
 		if (category.isCumulative) {
-			carryOver = await this.calculateRollover(categoryId, month, year);
+			carryOver = await this.calculateRollover(categoryId, category.userId, month, year);
 		}
 
 		try {
@@ -99,9 +99,10 @@ export class BudgetRolloverService {
 				where: { id: { in: uniqueCategoryIds } },
 				select: {
 					id: true,
+					userId: true,
 					isCumulative: true,
 				},
-			}),
+			}) as Promise<Array<{ id: number; userId: number; isCumulative: boolean }>>,
 		]);
 
 		for (const period of existingPeriods) {
@@ -115,7 +116,7 @@ export class BudgetRolloverService {
 			for (const category of missingCategories) {
 				let carryOver = 0;
 				if (category.isCumulative) {
-					carryOver = await this.calculateRollover(category.id, month, year);
+					carryOver = await this.calculateRollover(category.id, category.userId, month, year);
 				}
 
 				missingPeriodData.push({
@@ -154,6 +155,7 @@ export class BudgetRolloverService {
 	 */
 	async calculateRollover(
 		categoryId: number,
+		userId: number,
 		targetMonth: number,
 		targetYear: number,
 		visited = new Set<string>()
@@ -190,6 +192,7 @@ export class BudgetRolloverService {
 
 		const spending = await this._db.transaction.aggregate({
 			where: {
+				userId,
 				categoryId,
 				type: 'expense',
 				cashLot: {
@@ -238,14 +241,14 @@ export class BudgetRolloverService {
 
 		if (visited.has(key)) return 0;
 
-		const hasEarlierActivity = await this.hasBudgetActivityBefore(category.id, prevYear, prevMonth);
+		const hasEarlierActivity = await this.hasBudgetActivityBefore(category.id, category.userId, prevYear, prevMonth);
 		if (!hasEarlierActivity) return 0;
 
 		visited.add(key);
-		return this.calculateRollover(category.id, prevMonth, prevYear, visited);
+		return this.calculateRollover(category.id, category.userId, prevMonth, prevYear, visited);
 	}
 
-	private async hasBudgetActivityBefore(categoryId: number, year: number, month: number): Promise<boolean> {
+	private async hasBudgetActivityBefore(categoryId: number, userId: number, year: number, month: number): Promise<boolean> {
 		const [olderPeriod, olderTransaction] = await Promise.all([
 			this._db.budgetPeriod.findFirst({
 				where: {
@@ -256,6 +259,7 @@ export class BudgetRolloverService {
 			}),
 			this._db.transaction.findFirst({
 				where: {
+					userId,
 					categoryId,
 					type: 'expense',
 					cashLot: {
@@ -302,14 +306,14 @@ export class BudgetRolloverService {
 		let totalIncoming = 0;
 
 		for (const rule of rules) {
-			const sourceSurplus = await this.calculateSourceSurplus(rule.sourceCategoryId, targetMonth, targetYear);
+			const sourceSurplus = await this.calculateSourceSurplus(rule.sourceCategoryId, userId, targetMonth, targetYear);
 			totalIncoming += sourceSurplus;
 		}
 
 		return totalIncoming;
 	}
 
-	private async calculateSourceSurplus(categoryId: number, targetMonth: number, targetYear: number): Promise<number> {
+	private async calculateSourceSurplus(categoryId: number, userId: number, targetMonth: number, targetYear: number): Promise<number> {
 		const prevDate = dayjs(`${targetYear}-${targetMonth}-01`).subtract(1, 'month');
 		const prevMonth = prevDate.month() + 1;
 		const prevYear = prevDate.year();
@@ -334,6 +338,7 @@ export class BudgetRolloverService {
 
 		const spending = await this._db.transaction.aggregate({
 			where: {
+				userId,
 				categoryId,
 				type: 'expense',
 				cashLot: {

--- a/modules/budgets/budget-rollover.service.ts
+++ b/modules/budgets/budget-rollover.service.ts
@@ -192,6 +192,9 @@ export class BudgetRolloverService {
 			where: {
 				categoryId,
 				type: 'expense',
+				cashLot: {
+					is: null,
+				},
 				date: {
 					gte: startDate,
 					lte: endDate,
@@ -255,6 +258,9 @@ export class BudgetRolloverService {
 				where: {
 					categoryId,
 					type: 'expense',
+					cashLot: {
+						is: null,
+					},
 					date: { lt: dayjs(`${year}-${month}-01`).startOf('month').toDate() },
 				},
 				select: { id: true },
@@ -330,6 +336,9 @@ export class BudgetRolloverService {
 			where: {
 				categoryId,
 				type: 'expense',
+				cashLot: {
+					is: null,
+				},
 				date: {
 					gte: startDate,
 					lte: endDate,

--- a/modules/cash-lots/allocation.service.test.ts
+++ b/modules/cash-lots/allocation.service.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@jest/globals';
+import { CashLotAllocationService } from './allocation.service';
+
+describe('CashLotAllocationService', () => {
+	it('allocates cash lots using FIFO order', () => {
+		const result = CashLotAllocationService.allocateFifo(
+			[
+				{
+					id: 2,
+					remainingAmount: 100_000,
+					exchangeRate: 1250,
+					withdrawalDate: new Date('2026-04-10T10:00:00.000Z'),
+				},
+				{
+					id: 1,
+					remainingAmount: 120_000,
+					exchangeRate: 1200,
+					withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				},
+			],
+			150_000
+		);
+
+		expect(result.remainingAmount).toBe(0);
+		expect(result.totalAllocated).toBe(150_000);
+		expect(result.allocations).toEqual([
+			{
+				cashLotId: 1,
+				allocatedAmount: 120_000,
+				exchangeRate: 1200,
+				sourceEquivalentAmount: 100,
+			},
+			{
+				cashLotId: 2,
+				allocatedAmount: 30_000,
+				exchangeRate: 1250,
+				sourceEquivalentAmount: 24,
+			},
+		]);
+	});
+
+	it('returns the remaining amount when the lot balance is insufficient', () => {
+		const result = CashLotAllocationService.allocateFifo(
+			[
+				{
+					id: 1,
+					remainingAmount: 20_000,
+					exchangeRate: 1200,
+					withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				},
+			],
+			25_000
+		);
+
+		expect(result.totalAllocated).toBe(20_000);
+		expect(result.remainingAmount).toBe(5_000);
+		expect(result.allocations).toEqual([
+			{
+				cashLotId: 1,
+				allocatedAmount: 20_000,
+				exchangeRate: 1200,
+				sourceEquivalentAmount: 16.67,
+			},
+		]);
+	});
+});

--- a/modules/cash-lots/allocation.service.test.ts
+++ b/modules/cash-lots/allocation.service.test.ts
@@ -63,4 +63,41 @@ describe('CashLotAllocationService', () => {
 			},
 		]);
 	});
+
+	it('breaks same-day tie by lower lot id first', () => {
+		const result = CashLotAllocationService.allocateFifo(
+			[
+				{
+					id: 9,
+					remainingAmount: 50_000,
+					exchangeRate: 1_200,
+					withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				},
+				{
+					id: 3,
+					remainingAmount: 50_000,
+					exchangeRate: 1_250,
+					withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				},
+			],
+			60_000
+		);
+
+		expect(result.totalAllocated).toBe(60_000);
+		expect(result.remainingAmount).toBe(0);
+		expect(result.allocations).toEqual([
+			{
+				cashLotId: 3,
+				allocatedAmount: 50_000,
+				exchangeRate: 1_250,
+				sourceEquivalentAmount: 40,
+			},
+			{
+				cashLotId: 9,
+				allocatedAmount: 10_000,
+				exchangeRate: 1_200,
+				sourceEquivalentAmount: 8.33,
+			},
+		]);
+	});
 });

--- a/modules/cash-lots/allocation.service.ts
+++ b/modules/cash-lots/allocation.service.ts
@@ -1,0 +1,88 @@
+export interface CashLotSourceRow {
+	id: number;
+	remainingAmount: number;
+	exchangeRate: number;
+	withdrawalDate: Date;
+}
+
+export interface CashLotAllocationPlan {
+	cashLotId: number;
+	allocatedAmount: number;
+	exchangeRate: number;
+	sourceEquivalentAmount: number;
+}
+
+export interface CashLotAllocationResult {
+	allocations: CashLotAllocationPlan[];
+	remainingAmount: number;
+	totalAllocated: number;
+}
+
+function roundMoney(value: number): number {
+	return Math.round((Number.isFinite(value) ? value : 0) * 100) / 100;
+}
+
+function roundRate(value: number): number {
+	return Math.round((Number.isFinite(value) ? value : 0) * 1_000_000) / 1_000_000;
+}
+
+export class AllocationService {
+	allocateFifo(lots: CashLotSourceRow[], requiredAmount: number): CashLotAllocationResult {
+		const normalizedRequiredAmount = roundMoney(requiredAmount);
+		if (normalizedRequiredAmount <= 0) {
+			return {
+				allocations: [],
+				remainingAmount: 0,
+				totalAllocated: 0,
+			};
+		}
+
+		const sortedLots = [...lots].sort((left, right) => {
+			const timeDelta = left.withdrawalDate.getTime() - right.withdrawalDate.getTime();
+			if (timeDelta !== 0) {
+				return timeDelta;
+			}
+
+			return left.id - right.id;
+		});
+
+		const allocations: CashLotAllocationPlan[] = [];
+		let remainingAmount = normalizedRequiredAmount;
+
+		for (const lot of sortedLots) {
+			if (remainingAmount <= 0) {
+				break;
+			}
+
+			const availableAmount = roundMoney(lot.remainingAmount);
+			if (availableAmount <= 0) {
+				continue;
+			}
+
+			const allocatedAmount = roundMoney(Math.min(availableAmount, remainingAmount));
+			if (allocatedAmount <= 0) {
+				continue;
+			}
+
+			const exchangeRate = roundRate(lot.exchangeRate);
+			const sourceEquivalentAmount = exchangeRate > 0 ? roundMoney(allocatedAmount / exchangeRate) : 0;
+
+			allocations.push({
+				cashLotId: lot.id,
+				allocatedAmount,
+				exchangeRate,
+				sourceEquivalentAmount,
+			});
+
+			remainingAmount = roundMoney(remainingAmount - allocatedAmount);
+		}
+
+		return {
+			allocations,
+			remainingAmount,
+			totalAllocated: roundMoney(normalizedRequiredAmount - remainingAmount),
+		};
+	}
+}
+
+export const CashLotAllocationService = new AllocationService();

--- a/modules/cash-lots/cash-lot.service.test.ts
+++ b/modules/cash-lots/cash-lot.service.test.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { mockDeep, type DeepMockProxy } from 'jest-mock-extended';
 import { CashLotService } from './cash-lot.service';
+import { CashLotAllocationService } from './allocation.service';
 import { AppError } from '../../src/lib/appError';
 
 type TestTransaction = {
@@ -21,6 +22,7 @@ describe('CashLotService', () => {
 	beforeEach(() => {
 		service = new CashLotService();
 		db = mockDeep<PrismaClient>();
+		jest.restoreAllMocks();
 		jest.clearAllMocks();
 	});
 
@@ -77,6 +79,107 @@ describe('CashLotService', () => {
 			id: 1,
 			destinationAmount: new Decimal(120000),
 		});
+	});
+
+	it('returns withdrawal lot details by transaction id', async () => {
+		db.cashLot.findFirst.mockResolvedValue({
+			id: 99,
+			userId: 1,
+			withdrawalTransactionId: 77,
+			withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(120000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			allocations: [],
+			withdrawalTransaction: null,
+		} as never);
+
+		const lot = await service.getWithdrawalLotByTransactionId(77, 1, db as never);
+
+		expect(lot).toMatchObject({
+			id: 99,
+			withdrawalTransactionId: 77,
+		});
+		expect(db.cashLot.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					withdrawalTransactionId: 77,
+					userId: 1,
+				},
+			})
+		);
+	});
+
+	it('returns expense allocations by transaction id', async () => {
+		db.cashLotAllocation.findMany.mockResolvedValue([
+			{
+				id: 1,
+				userId: 1,
+				cashLotId: 99,
+				expenseTransactionId: 88,
+				allocatedAmount: new Decimal(5000),
+				exchangeRate: new Decimal(1200),
+				createdAt: new Date('2026-04-02T10:00:00.000Z'),
+				cashLot: {
+					id: 99,
+					userId: 1,
+					withdrawalTransactionId: 77,
+					withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+					sourceAmount: new Decimal(100),
+					sourceCurrency: 'USD',
+					destinationAmount: new Decimal(120000),
+					destinationCurrency: 'ARS',
+					exchangeRate: new Decimal(1200),
+					remainingAmount: new Decimal(115000),
+					migrationStatus: 'linked',
+					createdAt: new Date('2026-04-01T10:00:00.000Z'),
+					updatedAt: new Date('2026-04-02T10:00:00.000Z'),
+					withdrawalTransaction: null,
+				},
+			},
+		] as never);
+
+		const allocations = await service.getExpenseAllocations(88, 1, db as never);
+
+		expect(allocations).toHaveLength(1);
+		expect(db.cashLotAllocation.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					expenseTransactionId: 88,
+					userId: 1,
+				},
+			})
+		);
+	});
+
+	it('throws when creating a withdrawal cash lot with non-positive values', async () => {
+		const transaction: TestTransaction = {
+			id: 13,
+			userId: 1,
+			date: new Date('2026-04-01T10:00:00.000Z'),
+			currency: 'USD',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+		} as never;
+
+		await expect(
+			service.createWithdrawalCashLot(
+				transaction as never,
+				{
+					destinationAmount: 0,
+					destinationCurrency: 'ARS',
+					exchangeRate: 1200,
+				},
+				db as never
+			)
+		).rejects.toMatchObject({ statusCode: 400 });
+		expect(db.cashLot.create).not.toHaveBeenCalled();
 	});
 
 	it('updates an existing withdrawal cash lot when no allocations exist', async () => {
@@ -160,6 +263,50 @@ describe('CashLotService', () => {
 			destinationAmount: new Decimal(130000),
 			remainingAmount: new Decimal(130000),
 		});
+	});
+
+	it('creates a withdrawal cash lot when updating and no cash lot exists yet', async () => {
+		const transaction: TestTransaction = {
+			id: 14,
+			userId: 1,
+			date: new Date('2026-04-03T10:00:00.000Z'),
+			currency: 'USD',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+		} as never;
+
+		db.cashLot.findFirst.mockResolvedValue(null);
+		db.cashLot.create.mockResolvedValue({
+			id: 15,
+			userId: 1,
+			withdrawalTransactionId: 14,
+			withdrawalDate: transaction.date,
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(120000),
+			migrationStatus: 'linked',
+			createdAt: transaction.date,
+			updatedAt: transaction.date,
+		} as never);
+
+		const result = await service.updateWithdrawalCashLot(
+			transaction as never,
+			{
+				destinationAmount: 120000,
+				destinationCurrency: 'ARS',
+				exchangeRate: 1200,
+			},
+			db as never
+		);
+
+		expect(result).toMatchObject({
+			id: 15,
+			destinationAmount: new Decimal(120000),
+		});
+		expect(db.cashLot.create).toHaveBeenCalledTimes(1);
 	});
 
 	it('rejects withdrawal date edits when allocations already exist', async () => {
@@ -272,6 +419,88 @@ describe('CashLotService', () => {
 		});
 		expect(db.cashLot.updateMany).toHaveBeenCalledTimes(2);
 		expect(db.cashLotAllocation.create).toHaveBeenCalledTimes(2);
+	});
+
+	it('throws when a selected cash lot disappears during allocation', async () => {
+		const transaction: TestTransaction = {
+			id: 23,
+			userId: 1,
+			date: new Date('2026-04-02T12:00:00.000Z'),
+			currency: 'ARS',
+			amount: new Decimal(10000),
+			originalCurrencyAmount: new Decimal(10000),
+		} as never;
+
+		db.cashLot.findMany.mockResolvedValue([
+			{
+				id: 1,
+				userId: 1,
+				withdrawalTransactionId: 10,
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
+				remainingAmount: new Decimal(120000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-01T10:00:00.000Z'),
+				updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			},
+		] as never);
+		db.cashLot.updateMany.mockResolvedValue({ count: 0 });
+
+		await expect(service.allocateCashExpense(transaction as never, db as never)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(db.cashLotAllocation.create).not.toHaveBeenCalled();
+	});
+
+	it('throws when an allocation references a missing lot', async () => {
+		const transaction: TestTransaction = {
+			id: 24,
+			userId: 1,
+			date: new Date('2026-04-02T12:00:00.000Z'),
+			currency: 'ARS',
+			amount: new Decimal(10000),
+			originalCurrencyAmount: new Decimal(10000),
+		} as never;
+
+		db.cashLot.findMany.mockResolvedValue([
+			{
+				id: 1,
+				userId: 1,
+				withdrawalTransactionId: 10,
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
+				remainingAmount: new Decimal(120000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-01T10:00:00.000Z'),
+				updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			},
+		] as never);
+		jest.spyOn(CashLotAllocationService, 'allocateFifo').mockReturnValue({
+			allocations: [
+				{
+					cashLotId: 999,
+					allocatedAmount: 10000,
+					exchangeRate: 1200,
+					sourceEquivalentAmount: 8.33,
+				},
+			],
+			remainingAmount: 0,
+			totalAllocated: 10000,
+		});
+
+		await expect(service.allocateCashExpense(transaction as never, db as never)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(db.cashLot.updateMany).not.toHaveBeenCalled();
+		expect(db.cashLotAllocation.create).not.toHaveBeenCalled();
 	});
 
 	it('returns a zero allocation result for zero-amount cash expenses', async () => {
@@ -392,6 +621,53 @@ describe('CashLotService', () => {
 		});
 	});
 
+	it('returns zero restorations when an expense has no allocations', async () => {
+		db.cashLotAllocation.findMany.mockResolvedValue([] as never);
+
+		const restored = await service.restoreExpenseAllocations(999, 1, db as never);
+
+		expect(restored).toBe(0);
+		expect(db.cashLot.updateMany).not.toHaveBeenCalled();
+		expect(db.cashLotAllocation.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it('throws when restoring a cash lot that changed concurrently', async () => {
+		db.cashLotAllocation.findMany.mockResolvedValue([
+			{
+				id: 1,
+				userId: 1,
+				cashLotId: 10,
+				expenseTransactionId: 20,
+				allocatedAmount: new Decimal(50000),
+				exchangeRate: new Decimal(1200),
+				createdAt: new Date('2026-04-02T12:00:00.000Z'),
+			},
+		] as never);
+		db.cashLot.findMany.mockResolvedValue([
+			{
+				id: 10,
+				userId: 1,
+				withdrawalTransactionId: 5,
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
+				remainingAmount: new Decimal(25000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-01T10:00:00.000Z'),
+				updatedAt: new Date('2026-04-02T12:00:00.000Z'),
+			},
+		] as never);
+		db.cashLot.updateMany.mockResolvedValue({ count: 0 });
+
+		await expect(service.restoreExpenseAllocations(20, 1, db as never)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(db.cashLotAllocation.deleteMany).not.toHaveBeenCalled();
+	});
+
 	it('blocks withdrawal deletion when the lot is already used', async () => {
 		db.cashLot.findFirst.mockResolvedValue({
 			id: 1,
@@ -409,5 +685,14 @@ describe('CashLotService', () => {
 		} as never);
 
 		await expect(service.deleteWithdrawalCashLot(10, 1, db as never)).rejects.toBeInstanceOf(AppError);
+	});
+
+	it('returns null when trying to delete a withdrawal cash lot that does not exist', async () => {
+		db.cashLot.findFirst.mockResolvedValue(null);
+
+		const result = await service.deleteWithdrawalCashLot(999, 1, db as never);
+
+		expect(result).toBeNull();
+		expect(db.cashLot.delete).not.toHaveBeenCalled();
 	});
 });

--- a/modules/cash-lots/cash-lot.service.test.ts
+++ b/modules/cash-lots/cash-lot.service.test.ts
@@ -1,41 +1,9 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { PrismaClient } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
+import { mockDeep, type DeepMockProxy } from 'jest-mock-extended';
 import { CashLotService } from './cash-lot.service';
 import { AppError } from '../../src/lib/appError';
-
-type AsyncMock = jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-
-interface CashLotDbMock {
-	cashLot: {
-		create: AsyncMock;
-		findFirst: AsyncMock;
-		findMany: AsyncMock;
-		update: AsyncMock;
-		delete: AsyncMock;
-	};
-	cashLotAllocation: {
-		create: AsyncMock;
-		findMany: AsyncMock;
-		deleteMany: AsyncMock;
-	};
-}
-
-function createDbMock(): CashLotDbMock {
-	return {
-		cashLot: {
-			create: jest.fn() as AsyncMock,
-			findFirst: jest.fn() as AsyncMock,
-			findMany: jest.fn() as AsyncMock,
-			update: jest.fn() as AsyncMock,
-			delete: jest.fn() as AsyncMock,
-		},
-		cashLotAllocation: {
-			create: jest.fn() as AsyncMock,
-			findMany: jest.fn() as AsyncMock,
-			deleteMany: jest.fn() as AsyncMock,
-		},
-	};
-}
 
 type TestTransaction = {
 	id: number;
@@ -47,9 +15,16 @@ type TestTransaction = {
 };
 
 describe('CashLotService', () => {
+	let service: CashLotService;
+	let db: DeepMockProxy<PrismaClient>;
+
+	beforeEach(() => {
+		service = new CashLotService();
+		db = mockDeep<PrismaClient>();
+		jest.clearAllMocks();
+	});
+
 	it('creates a withdrawal cash lot with the destination remaining amount', async () => {
-		const service = new CashLotService();
-		const db = createDbMock() as CashLotDbMock;
 		const transaction: TestTransaction = {
 			id: 10,
 			userId: 1,
@@ -73,7 +48,7 @@ describe('CashLotService', () => {
 			migrationStatus: 'linked',
 			createdAt: new Date('2026-04-01T10:00:00.000Z'),
 			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
-		});
+		} as never);
 
 		const result = await service.createWithdrawalCashLot(
 			transaction as never,
@@ -104,9 +79,134 @@ describe('CashLotService', () => {
 		});
 	});
 
+	it('updates an existing withdrawal cash lot when no allocations exist', async () => {
+		const transaction: TestTransaction = {
+			id: 11,
+			userId: 1,
+			date: new Date('2026-04-03T10:00:00.000Z'),
+			currency: 'USD',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+		} as never;
+
+		db.cashLot.findFirst.mockResolvedValue({
+			id: 7,
+			userId: 1,
+			withdrawalTransactionId: 11,
+			withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(120000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			allocations: [],
+		} as never);
+		db.cashLot.update.mockResolvedValue({
+			id: 7,
+			userId: 1,
+			withdrawalTransactionId: 11,
+			withdrawalDate: transaction.date,
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(130000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1300),
+			remainingAmount: new Decimal(130000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-03T10:00:00.000Z'),
+			allocations: [],
+		} as never);
+
+		const result = await service.updateWithdrawalCashLot(
+			transaction as never,
+			{
+				destinationAmount: 130000,
+				destinationCurrency: 'ARS',
+				exchangeRate: 1300,
+			},
+			db as never
+		);
+
+		expect(db.cashLot.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					withdrawalTransactionId: 11,
+					userId: 1,
+				},
+			})
+		);
+		expect(db.cashLot.update).toHaveBeenCalledWith({
+			where: {
+				id: 7,
+			},
+			data: {
+				withdrawalDate: transaction.date,
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(130000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1300),
+				remainingAmount: new Decimal(130000),
+				migrationStatus: 'linked',
+			},
+		});
+		expect(result).toMatchObject({
+			id: 7,
+			destinationAmount: new Decimal(130000),
+			remainingAmount: new Decimal(130000),
+		});
+	});
+
+	it('rejects withdrawal date edits when allocations already exist', async () => {
+		const transaction: TestTransaction = {
+			id: 12,
+			userId: 1,
+			date: new Date('2026-04-03T10:00:00.000Z'),
+			currency: 'USD',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+		} as never;
+
+		db.cashLot.findFirst.mockResolvedValue({
+			id: 8,
+			userId: 1,
+			withdrawalTransactionId: 12,
+			withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(100000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			allocations: [{ id: 1 }],
+		} as never);
+
+		await expect(
+			service.updateWithdrawalCashLot(
+				transaction as never,
+				{
+					destinationAmount: 120000,
+					destinationCurrency: 'ARS',
+					exchangeRate: 1200,
+				},
+				db as never
+			)
+		).rejects.toMatchObject({
+			statusCode: 409,
+		});
+
+		expect(db.cashLot.update).not.toHaveBeenCalled();
+	});
+
 	it('allocates cash expenses using FIFO and updates remaining cash lots', async () => {
-		const service = new CashLotService();
-		const db = createDbMock() as CashLotDbMock;
 		const transaction: TestTransaction = {
 			id: 20,
 			userId: 1,
@@ -119,19 +219,37 @@ describe('CashLotService', () => {
 		db.cashLot.findMany.mockResolvedValue([
 			{
 				id: 1,
-				remainingAmount: new Decimal(120000),
-				exchangeRate: new Decimal(1200),
+				userId: 1,
+				withdrawalTransactionId: 10,
 				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
+				remainingAmount: new Decimal(120000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-01T10:00:00.000Z'),
+				updatedAt: new Date('2026-04-01T10:00:00.000Z'),
 			},
 			{
 				id: 2,
-				remainingAmount: new Decimal(100000),
-				exchangeRate: new Decimal(1250),
+				userId: 1,
+				withdrawalTransactionId: 11,
 				withdrawalDate: new Date('2026-04-02T09:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(100000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1250),
+				remainingAmount: new Decimal(100000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-02T09:00:00.000Z'),
+				updatedAt: new Date('2026-04-02T09:00:00.000Z'),
 			},
-		]);
-		db.cashLot.update.mockResolvedValue({});
-		db.cashLotAllocation.create.mockResolvedValue({});
+		] as never);
+		db.cashLot.updateMany.mockResolvedValue({ count: 1 });
+		db.cashLotAllocation.create.mockResolvedValue({} as never);
 
 		const result = await service.allocateCashExpense(transaction as never, db as never);
 
@@ -152,14 +270,67 @@ describe('CashLotService', () => {
 				},
 			],
 		});
-		expect(db.cashLot.update).toHaveBeenCalledTimes(2);
+		expect(db.cashLot.updateMany).toHaveBeenCalledTimes(2);
 		expect(db.cashLotAllocation.create).toHaveBeenCalledTimes(2);
 	});
 
-	it('restores cash lots after deleting an expense transaction', async () => {
-		const service = new CashLotService();
-		const db = createDbMock() as CashLotDbMock;
+	it('returns a zero allocation result for zero-amount cash expenses', async () => {
+		const transaction: TestTransaction = {
+			id: 21,
+			userId: 1,
+			date: new Date('2026-04-02T12:00:00.000Z'),
+			currency: 'ARS',
+			amount: new Decimal(0),
+			originalCurrencyAmount: new Decimal(0),
+		} as never;
 
+		const result = await service.allocateCashExpense(transaction as never, db as never);
+
+		expect(result).toEqual({
+			allocations: [],
+			totalAllocated: 0,
+		});
+		expect(db.cashLot.findMany).not.toHaveBeenCalled();
+		expect(db.cashLot.updateMany).not.toHaveBeenCalled();
+		expect(db.cashLotAllocation.create).not.toHaveBeenCalled();
+	});
+
+	it('rejects cash expense allocation when cash balance is insufficient', async () => {
+		const transaction: TestTransaction = {
+			id: 22,
+			userId: 1,
+			date: new Date('2026-04-02T12:00:00.000Z'),
+			currency: 'ARS',
+			amount: new Decimal(25000),
+			originalCurrencyAmount: new Decimal(25000),
+		} as never;
+
+		db.cashLot.findMany.mockResolvedValue([
+			{
+				id: 1,
+				userId: 1,
+				withdrawalTransactionId: 10,
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
+				remainingAmount: new Decimal(20000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-01T10:00:00.000Z'),
+				updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			},
+		] as never);
+
+		await expect(service.allocateCashExpense(transaction as never, db as never)).rejects.toMatchObject({
+			statusCode: 422,
+		});
+		expect(db.cashLot.updateMany).not.toHaveBeenCalled();
+		expect(db.cashLotAllocation.create).not.toHaveBeenCalled();
+	});
+
+	it('restores cash lots after deleting an expense transaction', async () => {
 		db.cashLotAllocation.findMany.mockResolvedValue([
 			{
 				id: 1,
@@ -168,6 +339,7 @@ describe('CashLotService', () => {
 				expenseTransactionId: 20,
 				allocatedAmount: new Decimal(50000),
 				exchangeRate: new Decimal(1200),
+				createdAt: new Date('2026-04-02T12:00:00.000Z'),
 			},
 			{
 				id: 2,
@@ -176,23 +348,38 @@ describe('CashLotService', () => {
 				expenseTransactionId: 20,
 				allocatedAmount: new Decimal(25000),
 				exchangeRate: new Decimal(1200),
+				createdAt: new Date('2026-04-02T12:01:00.000Z'),
 			},
-		]);
+		] as never);
 		db.cashLot.findMany.mockResolvedValue([
 			{
 				id: 10,
 				userId: 1,
+				withdrawalTransactionId: 5,
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
 				remainingAmount: new Decimal(25000),
+				migrationStatus: 'linked',
+				createdAt: new Date('2026-04-01T10:00:00.000Z'),
+				updatedAt: new Date('2026-04-02T12:00:00.000Z'),
 			},
-		]);
-		db.cashLot.update.mockResolvedValue({});
+		] as never);
+		db.cashLot.updateMany.mockResolvedValue({ count: 1 });
 		db.cashLotAllocation.deleteMany.mockResolvedValue({ count: 2 });
 
 		const restored = await service.restoreExpenseAllocations(20, 1, db as never);
 
 		expect(restored).toBe(2);
-		expect(db.cashLot.update).toHaveBeenCalledWith({
-			where: { id: 10 },
+		expect(db.cashLot.updateMany).toHaveBeenCalledWith({
+			where: {
+				id: 10,
+				userId: 1,
+				remainingAmount: new Decimal(25000),
+			},
 			data: {
 				remainingAmount: new Decimal(100000),
 			},
@@ -206,9 +393,6 @@ describe('CashLotService', () => {
 	});
 
 	it('blocks withdrawal deletion when the lot is already used', async () => {
-		const service = new CashLotService();
-		const db = createDbMock() as CashLotDbMock;
-
 		db.cashLot.findFirst.mockResolvedValue({
 			id: 1,
 			userId: 1,
@@ -222,7 +406,7 @@ describe('CashLotService', () => {
 			remainingAmount: new Decimal(100000),
 			migrationStatus: 'linked',
 			allocations: [{ id: 1 }],
-		});
+		} as never);
 
 		await expect(service.deleteWithdrawalCashLot(10, 1, db as never)).rejects.toBeInstanceOf(AppError);
 	});

--- a/modules/cash-lots/cash-lot.service.test.ts
+++ b/modules/cash-lots/cash-lot.service.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { Decimal } from '@prisma/client/runtime/library';
+import { CashLotService } from './cash-lot.service';
+import { AppError } from '../../src/lib/appError';
+
+type AsyncMock = jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+
+interface CashLotDbMock {
+	cashLot: {
+		create: AsyncMock;
+		findFirst: AsyncMock;
+		findMany: AsyncMock;
+		update: AsyncMock;
+		delete: AsyncMock;
+	};
+	cashLotAllocation: {
+		create: AsyncMock;
+		findMany: AsyncMock;
+		deleteMany: AsyncMock;
+	};
+}
+
+function createDbMock(): CashLotDbMock {
+	return {
+		cashLot: {
+			create: jest.fn() as AsyncMock,
+			findFirst: jest.fn() as AsyncMock,
+			findMany: jest.fn() as AsyncMock,
+			update: jest.fn() as AsyncMock,
+			delete: jest.fn() as AsyncMock,
+		},
+		cashLotAllocation: {
+			create: jest.fn() as AsyncMock,
+			findMany: jest.fn() as AsyncMock,
+			deleteMany: jest.fn() as AsyncMock,
+		},
+	};
+}
+
+type TestTransaction = {
+	id: number;
+	userId: number;
+	date: Date;
+	currency: string;
+	amount: Decimal;
+	originalCurrencyAmount: Decimal;
+};
+
+describe('CashLotService', () => {
+	it('creates a withdrawal cash lot with the destination remaining amount', async () => {
+		const service = new CashLotService();
+		const db = createDbMock() as CashLotDbMock;
+		const transaction: TestTransaction = {
+			id: 10,
+			userId: 1,
+			date: new Date('2026-04-01T10:00:00.000Z'),
+			currency: 'USD',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+		} as never;
+
+		db.cashLot.create.mockResolvedValue({
+			id: 1,
+			userId: 1,
+			withdrawalTransactionId: 10,
+			withdrawalDate: transaction.date,
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(120000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+		});
+
+		const result = await service.createWithdrawalCashLot(
+			transaction as never,
+			{
+				destinationAmount: 120000,
+				destinationCurrency: 'ARS',
+				exchangeRate: 1200,
+			},
+			db as never
+		);
+
+		expect(db.cashLot.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				userId: 1,
+				withdrawalTransactionId: 10,
+				sourceAmount: 100,
+				sourceCurrency: 'USD',
+				destinationAmount: 120000,
+				destinationCurrency: 'ARS',
+				exchangeRate: 1200,
+				remainingAmount: 120000,
+				migrationStatus: 'linked',
+			}),
+		});
+		expect(result).toMatchObject({
+			id: 1,
+			destinationAmount: new Decimal(120000),
+		});
+	});
+
+	it('allocates cash expenses using FIFO and updates remaining cash lots', async () => {
+		const service = new CashLotService();
+		const db = createDbMock() as CashLotDbMock;
+		const transaction: TestTransaction = {
+			id: 20,
+			userId: 1,
+			date: new Date('2026-04-02T12:00:00.000Z'),
+			currency: 'ARS',
+			amount: new Decimal(150000),
+			originalCurrencyAmount: new Decimal(150000),
+		} as never;
+
+		db.cashLot.findMany.mockResolvedValue([
+			{
+				id: 1,
+				remainingAmount: new Decimal(120000),
+				exchangeRate: new Decimal(1200),
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+			},
+			{
+				id: 2,
+				remainingAmount: new Decimal(100000),
+				exchangeRate: new Decimal(1250),
+				withdrawalDate: new Date('2026-04-02T09:00:00.000Z'),
+			},
+		]);
+		db.cashLot.update.mockResolvedValue({});
+		db.cashLotAllocation.create.mockResolvedValue({});
+
+		const result = await service.allocateCashExpense(transaction as never, db as never);
+
+		expect(result).toMatchObject({
+			totalAllocated: 150000,
+			allocations: [
+				{
+					cashLotId: 1,
+					allocatedAmount: 120000,
+					exchangeRate: 1200,
+					sourceEquivalentAmount: 100,
+				},
+				{
+					cashLotId: 2,
+					allocatedAmount: 30000,
+					exchangeRate: 1250,
+					sourceEquivalentAmount: 24,
+				},
+			],
+		});
+		expect(db.cashLot.update).toHaveBeenCalledTimes(2);
+		expect(db.cashLotAllocation.create).toHaveBeenCalledTimes(2);
+	});
+
+	it('restores cash lots after deleting an expense transaction', async () => {
+		const service = new CashLotService();
+		const db = createDbMock() as CashLotDbMock;
+
+		db.cashLotAllocation.findMany.mockResolvedValue([
+			{
+				id: 1,
+				userId: 1,
+				cashLotId: 10,
+				expenseTransactionId: 20,
+				allocatedAmount: new Decimal(50000),
+				exchangeRate: new Decimal(1200),
+			},
+			{
+				id: 2,
+				userId: 1,
+				cashLotId: 10,
+				expenseTransactionId: 20,
+				allocatedAmount: new Decimal(25000),
+				exchangeRate: new Decimal(1200),
+			},
+		]);
+		db.cashLot.findMany.mockResolvedValue([
+			{
+				id: 10,
+				userId: 1,
+				remainingAmount: new Decimal(25000),
+			},
+		]);
+		db.cashLot.update.mockResolvedValue({});
+		db.cashLotAllocation.deleteMany.mockResolvedValue({ count: 2 });
+
+		const restored = await service.restoreExpenseAllocations(20, 1, db as never);
+
+		expect(restored).toBe(2);
+		expect(db.cashLot.update).toHaveBeenCalledWith({
+			where: { id: 10 },
+			data: {
+				remainingAmount: new Decimal(100000),
+			},
+		});
+		expect(db.cashLotAllocation.deleteMany).toHaveBeenCalledWith({
+			where: {
+				expenseTransactionId: 20,
+				userId: 1,
+			},
+		});
+	});
+
+	it('blocks withdrawal deletion when the lot is already used', async () => {
+		const service = new CashLotService();
+		const db = createDbMock() as CashLotDbMock;
+
+		db.cashLot.findFirst.mockResolvedValue({
+			id: 1,
+			userId: 1,
+			withdrawalTransactionId: 10,
+			withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(100000),
+			migrationStatus: 'linked',
+			allocations: [{ id: 1 }],
+		});
+
+		await expect(service.deleteWithdrawalCashLot(10, 1, db as never)).rejects.toBeInstanceOf(AppError);
+	});
+});

--- a/modules/cash-lots/cash-lot.service.ts
+++ b/modules/cash-lots/cash-lot.service.ts
@@ -1,0 +1,349 @@
+import { CashLot, CashLotAllocation, Prisma, PrismaClient, Transaction } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+import { PrismaModule } from '../database/database.module';
+import { AppError } from '../../src/lib/appError';
+import logger from '../../src/lib/logger';
+import { CashLotAllocationService, type CashLotSourceRow } from './allocation.service';
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+type TransactionLike = Transaction & {
+	cashLot?: CashLot | null;
+	cashLotAllocations?: CashLotAllocation[];
+};
+
+function roundMoney(value: number): number {
+	return Math.round((Number.isFinite(value) ? value : 0) * 100) / 100;
+}
+
+function roundRate(value: number): number {
+	return Math.round((Number.isFinite(value) ? value : 0) * 1_000_000) / 1_000_000;
+}
+
+function toNumber(value: Decimal | number | null | undefined): number {
+	if (value === null || value === undefined) {
+		return 0;
+	}
+
+	return Number(value);
+}
+
+function normalizeCurrency(currency: string): string {
+	return currency.trim().toUpperCase();
+}
+
+export class CashLotService {
+	private _db: PrismaClient;
+
+	constructor() {
+		this._db = PrismaModule;
+	}
+
+	private get db() {
+		return this._db;
+	}
+
+	async getWithdrawalLotByTransactionId(transactionId: number, userId: number, db: DbClient = this.db) {
+		return db.cashLot.findFirst({
+			where: {
+				withdrawalTransactionId: transactionId,
+				userId,
+			},
+			include: {
+				allocations: {
+					orderBy: {
+						createdAt: 'asc',
+					},
+				},
+				withdrawalTransaction: {
+					include: {
+						category: true,
+						paymentMethod: true,
+					},
+				},
+			},
+		});
+	}
+
+	async getExpenseAllocations(expenseTransactionId: number, userId: number, db: DbClient = this.db) {
+		return db.cashLotAllocation.findMany({
+			where: {
+				expenseTransactionId,
+				userId,
+			},
+			include: {
+				cashLot: {
+					include: {
+						withdrawalTransaction: {
+							include: {
+								category: true,
+								paymentMethod: true,
+							},
+						},
+					},
+				},
+			},
+			orderBy: {
+				createdAt: 'asc',
+			},
+		});
+	}
+
+	async createWithdrawalCashLot(
+		transaction: TransactionLike,
+		args: {
+			destinationAmount: number;
+			destinationCurrency: string;
+			exchangeRate: number;
+			migrationStatus?: 'linked' | 'unlinked';
+		},
+		db: DbClient = this.db
+	) {
+		const sourceAmount = roundMoney(toNumber(transaction.originalCurrencyAmount ?? transaction.amount));
+		const sourceCurrency = normalizeCurrency(transaction.currency);
+		const destinationAmount = roundMoney(args.destinationAmount);
+		const destinationCurrency = normalizeCurrency(args.destinationCurrency);
+		const exchangeRate = roundRate(args.exchangeRate);
+
+		if (sourceAmount <= 0 || destinationAmount <= 0 || exchangeRate <= 0) {
+			throw new AppError('Withdrawal cash lot requires positive source amount, destination amount and exchange rate', 400);
+		}
+
+		return db.cashLot.create({
+			data: {
+				userId: transaction.userId,
+				withdrawalTransactionId: transaction.id,
+				withdrawalDate: transaction.date,
+				sourceAmount,
+				sourceCurrency,
+				destinationAmount,
+				destinationCurrency,
+				exchangeRate,
+				remainingAmount: destinationAmount,
+				migrationStatus: args.migrationStatus ?? 'linked',
+			},
+		});
+	}
+
+	async updateWithdrawalCashLot(
+		transaction: TransactionLike,
+		args: {
+			destinationAmount: number;
+			destinationCurrency: string;
+			exchangeRate: number;
+			migrationStatus?: 'linked' | 'unlinked';
+		},
+		db: DbClient = this.db
+	) {
+		const existingCashLot = await db.cashLot.findFirst({
+			where: {
+				withdrawalTransactionId: transaction.id,
+				userId: transaction.userId,
+			},
+			include: {
+				allocations: true,
+			},
+		});
+
+		if (!existingCashLot) {
+			return this.createWithdrawalCashLot(transaction, args, db);
+		}
+
+		const sourceAmount = roundMoney(toNumber(transaction.originalCurrencyAmount ?? transaction.amount));
+		const sourceCurrency = normalizeCurrency(transaction.currency);
+		const destinationAmount = roundMoney(args.destinationAmount);
+		const destinationCurrency = normalizeCurrency(args.destinationCurrency);
+		const exchangeRate = roundRate(args.exchangeRate);
+
+		if (sourceAmount <= 0 || destinationAmount <= 0 || exchangeRate <= 0) {
+			throw new AppError('Withdrawal cash lot requires positive source amount, destination amount and exchange rate', 400);
+		}
+
+		const hasAllocations = existingCashLot.allocations.length > 0;
+		const hasCoreChanges =
+			roundMoney(toNumber(existingCashLot.sourceAmount)) !== sourceAmount ||
+			normalizeCurrency(existingCashLot.sourceCurrency) !== sourceCurrency ||
+			roundMoney(toNumber(existingCashLot.destinationAmount)) !== destinationAmount ||
+			normalizeCurrency(existingCashLot.destinationCurrency) !== destinationCurrency ||
+			roundRate(toNumber(existingCashLot.exchangeRate)) !== exchangeRate;
+
+		if (hasAllocations && hasCoreChanges) {
+			throw new AppError('This withdrawal already has cash expenses linked to it and cannot be modified', 409);
+		}
+
+		return db.cashLot.update({
+			where: { id: existingCashLot.id },
+			data: {
+				withdrawalDate: transaction.date,
+				sourceAmount: new Decimal(sourceAmount),
+				sourceCurrency,
+				destinationAmount: new Decimal(destinationAmount),
+				destinationCurrency,
+				exchangeRate: new Decimal(exchangeRate),
+				remainingAmount: hasAllocations ? existingCashLot.remainingAmount : new Decimal(destinationAmount),
+				migrationStatus: args.migrationStatus ?? existingCashLot.migrationStatus,
+			},
+		});
+	}
+
+	async allocateCashExpense(transaction: TransactionLike, db: DbClient = this.db) {
+		const expenseAmount = roundMoney(toNumber(transaction.originalCurrencyAmount ?? transaction.amount));
+		const expenseCurrency = normalizeCurrency(transaction.currency);
+
+		if (expenseAmount <= 0) {
+			return {
+				allocations: [] as Array<{ cashLotId: number; allocatedAmount: number; exchangeRate: number; sourceEquivalentAmount: number }>,
+				totalAllocated: 0,
+			};
+		}
+
+		const availableLots = await db.cashLot.findMany({
+			where: {
+				userId: transaction.userId,
+				destinationCurrency: expenseCurrency,
+				migrationStatus: 'linked',
+				remainingAmount: {
+					gt: 0,
+				},
+				withdrawalDate: {
+					lte: transaction.date,
+				},
+			},
+			orderBy: [
+				{ withdrawalDate: 'asc' },
+				{ id: 'asc' },
+			],
+		});
+
+		const allocationPlan = CashLotAllocationService.allocateFifo(
+			availableLots.map((lot) => ({
+				id: lot.id,
+				remainingAmount: toNumber(lot.remainingAmount),
+				exchangeRate: toNumber(lot.exchangeRate),
+				withdrawalDate: lot.withdrawalDate,
+			} satisfies CashLotSourceRow)),
+			expenseAmount
+		);
+
+		if (allocationPlan.remainingAmount > 0) {
+			throw new AppError(
+				`Insufficient cash balance for ${expenseCurrency}. Missing ${allocationPlan.remainingAmount.toFixed(2)} ${expenseCurrency}.`,
+				422
+			);
+		}
+
+		let createdAllocationsCount = 0;
+
+		for (const allocation of allocationPlan.allocations) {
+			const lot = availableLots.find((row) => row.id === allocation.cashLotId);
+			if (!lot) {
+				throw new AppError('Cash lot allocation failed because the selected lot was not found', 409);
+			}
+
+			const updatedRemainingAmount = roundMoney(toNumber(lot.remainingAmount) - allocation.allocatedAmount);
+
+			await db.cashLot.update({
+				where: { id: lot.id },
+				data: {
+					remainingAmount: new Decimal(updatedRemainingAmount),
+				},
+			});
+
+			await db.cashLotAllocation.create({
+				data: {
+					userId: transaction.userId,
+					cashLotId: lot.id,
+					expenseTransactionId: transaction.id,
+					allocatedAmount: new Decimal(allocation.allocatedAmount),
+					exchangeRate: new Decimal(allocation.exchangeRate),
+				},
+			});
+			createdAllocationsCount += 1;
+		}
+
+		logger.info('Cash expense allocations created', {
+			userId: transaction.userId,
+			transactionId: transaction.id,
+			totalAllocated: allocationPlan.totalAllocated,
+			allocationCount: createdAllocationsCount,
+		});
+
+		return {
+			allocations: allocationPlan.allocations,
+			totalAllocated: allocationPlan.totalAllocated,
+		};
+	}
+
+	async restoreExpenseAllocations(expenseTransactionId: number, userId: number, db: DbClient = this.db) {
+		const allocations = await db.cashLotAllocation.findMany({
+			where: {
+				expenseTransactionId,
+				userId,
+			},
+		});
+
+		if (allocations.length === 0) {
+			return 0;
+		}
+
+		const cashLotIds = [...new Set(allocations.map((allocation) => allocation.cashLotId))];
+		const cashLots = await db.cashLot.findMany({
+			where: {
+				id: {
+					in: cashLotIds,
+				},
+				userId,
+			},
+		});
+
+		for (const cashLot of cashLots) {
+			const allocatedAmount = allocations
+				.filter((allocation) => allocation.cashLotId === cashLot.id)
+				.reduce((sum, allocation) => sum + toNumber(allocation.allocatedAmount), 0);
+
+			await db.cashLot.update({
+				where: { id: cashLot.id },
+				data: {
+					remainingAmount: new Decimal(roundMoney(toNumber(cashLot.remainingAmount) + allocatedAmount)),
+				},
+			});
+		}
+
+		await db.cashLotAllocation.deleteMany({
+			where: {
+				expenseTransactionId,
+				userId,
+			},
+		});
+
+		return allocations.length;
+	}
+
+	async deleteWithdrawalCashLot(transactionId: number, userId: number, db: DbClient = this.db) {
+		const cashLot = await db.cashLot.findFirst({
+			where: {
+				withdrawalTransactionId: transactionId,
+				userId,
+			},
+			include: {
+				allocations: true,
+			},
+		});
+
+		if (!cashLot) {
+			return null;
+		}
+
+		if (cashLot.allocations.length > 0 || roundMoney(toNumber(cashLot.remainingAmount)) < roundMoney(toNumber(cashLot.destinationAmount))) {
+			throw new AppError('This withdrawal already has cash expenses linked to it and cannot be deleted', 409);
+		}
+
+		return db.cashLot.delete({
+			where: {
+				id: cashLot.id,
+			},
+		});
+	}
+}
+
+export const CashLotServiceInstance = new CashLotService();

--- a/modules/cash-lots/cash-lot.service.ts
+++ b/modules/cash-lots/cash-lot.service.ts
@@ -161,6 +161,7 @@ export class CashLotService {
 
 		const hasAllocations = existingCashLot.allocations.length > 0;
 		const hasCoreChanges =
+			new Date(existingCashLot.withdrawalDate).getTime() !== new Date(transaction.date).getTime() ||
 			roundMoney(toNumber(existingCashLot.sourceAmount)) !== sourceAmount ||
 			normalizeCurrency(existingCashLot.sourceCurrency) !== sourceCurrency ||
 			roundMoney(toNumber(existingCashLot.destinationAmount)) !== destinationAmount ||
@@ -242,12 +243,20 @@ export class CashLotService {
 
 			const updatedRemainingAmount = roundMoney(toNumber(lot.remainingAmount) - allocation.allocatedAmount);
 
-			await db.cashLot.update({
-				where: { id: lot.id },
+			const updateResult = await db.cashLot.updateMany({
+				where: {
+					id: lot.id,
+					userId: transaction.userId,
+					remainingAmount: lot.remainingAmount,
+				},
 				data: {
 					remainingAmount: new Decimal(updatedRemainingAmount),
 				},
 			});
+
+			if (updateResult.count !== 1) {
+				throw new AppError('Cash lot allocation failed because the selected lot changed before it could be consumed', 409);
+			}
 
 			await db.cashLotAllocation.create({
 				data: {
@@ -301,12 +310,20 @@ export class CashLotService {
 				.filter((allocation) => allocation.cashLotId === cashLot.id)
 				.reduce((sum, allocation) => sum + toNumber(allocation.allocatedAmount), 0);
 
-			await db.cashLot.update({
-				where: { id: cashLot.id },
+			const updateResult = await db.cashLot.updateMany({
+				where: {
+					id: cashLot.id,
+					userId,
+					remainingAmount: cashLot.remainingAmount,
+				},
 				data: {
 					remainingAmount: new Decimal(roundMoney(toNumber(cashLot.remainingAmount) + allocatedAmount)),
 				},
 			});
+
+			if (updateResult.count !== 1) {
+				throw new AppError('Cash lot restoration failed because the selected lot changed before it could be restored', 409);
+			}
 		}
 
 		await db.cashLotAllocation.deleteMany({

--- a/modules/notifications/budget-checker.service.ts
+++ b/modules/notifications/budget-checker.service.ts
@@ -49,6 +49,9 @@ export class BudgetCheckerService implements IBudgetChecker {
         userId,
         categoryId,
         type: 'expense',
+        cashLot: {
+          is: null,
+        },
         date: {
           gte: startOfMonth,
         },

--- a/modules/notifications/notification.factory.ts
+++ b/modules/notifications/notification.factory.ts
@@ -111,6 +111,9 @@ export class NotificationFactory implements INotificationFactory {
           userId,
           categoryId,
           type: 'expense',
+          cashLot: {
+            is: null,
+          },
           date: { gte: startOfMonth },
         },
         _sum: { amount: true },

--- a/prisma/migrations/20260610194000_add_cash_lots/migration.sql
+++ b/prisma/migrations/20260610194000_add_cash_lots/migration.sql
@@ -17,6 +17,7 @@ CREATE TABLE `CashLot` (
   UNIQUE INDEX `CashLot_withdrawalTransactionId_key`(`withdrawalTransactionId`),
   INDEX `CashLot_userId_fkey`(`userId`),
   INDEX `CashLot_destinationCurrency_withdrawalDate_idx`(`destinationCurrency`, `withdrawalDate`),
+  INDEX `CashLot_user_dest_migration_withdrawal_id_idx`(`userId`, `destinationCurrency`, `migrationStatus`, `withdrawalDate`, `id`),
 
   CONSTRAINT `CashLot_userId_fkey`
     FOREIGN KEY (`userId`) REFERENCES `User`(`id`)
@@ -70,7 +71,20 @@ INSERT INTO `CashLot` (
 )
 SELECT
   t.`userId`,
-  t.`id`,
+  CASE
+    WHEN (
+      LOWER(COALESCE(t.`description`, '')) LIKE '%withdraw%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%withdrawal%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%atm%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%retiro%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%cash out%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%cash withdrawal%'
+    )
+    AND COALESCE(t.`amount`, 0) > 0
+    AND COALESCE(t.`originalCurrencyAmount`, 0) > 0
+    THEN t.`id`
+    ELSE NULL
+  END,
   t.`date`,
   COALESCE(t.`amount`, 0),
   'USD',

--- a/prisma/migrations/20260610194000_add_cash_lots/migration.sql
+++ b/prisma/migrations/20260610194000_add_cash_lots/migration.sql
@@ -1,0 +1,111 @@
+-- CreateTable
+CREATE TABLE `CashLot` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `userId` INT NOT NULL,
+  `withdrawalTransactionId` INT NULL,
+  `withdrawalDate` DATETIME(3) NOT NULL,
+  `sourceAmount` DECIMAL(10, 2) NOT NULL,
+  `sourceCurrency` VARCHAR(3) NOT NULL,
+  `destinationAmount` DECIMAL(10, 2) NOT NULL,
+  `destinationCurrency` VARCHAR(3) NOT NULL,
+  `exchangeRate` DECIMAL(10, 6) NOT NULL,
+  `remainingAmount` DECIMAL(10, 2) NOT NULL,
+  `migrationStatus` VARCHAR(20) NOT NULL DEFAULT 'linked',
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL,
+
+  UNIQUE INDEX `CashLot_withdrawalTransactionId_key`(`withdrawalTransactionId`),
+  INDEX `CashLot_userId_fkey`(`userId`),
+  INDEX `CashLot_destinationCurrency_withdrawalDate_idx`(`destinationCurrency`, `withdrawalDate`),
+
+  CONSTRAINT `CashLot_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `User`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `CashLot_withdrawalTransactionId_fkey`
+    FOREIGN KEY (`withdrawalTransactionId`) REFERENCES `Transaction`(`id`)
+    ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `CashLotAllocation` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `userId` INT NOT NULL,
+  `cashLotId` INT NOT NULL,
+  `expenseTransactionId` INT NOT NULL,
+  `allocatedAmount` DECIMAL(10, 2) NOT NULL,
+  `exchangeRate` DECIMAL(10, 6) NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+  UNIQUE INDEX `cash_lot_allocation_uq`(`cashLotId`, `expenseTransactionId`),
+  INDEX `CashLotAllocation_userId_fkey`(`userId`),
+  INDEX `CashLotAllocation_expenseTransactionId_fkey`(`expenseTransactionId`),
+
+  CONSTRAINT `CashLotAllocation_userId_fkey`
+    FOREIGN KEY (`userId`) REFERENCES `User`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `CashLotAllocation_cashLotId_fkey`
+    FOREIGN KEY (`cashLotId`) REFERENCES `CashLot`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `CashLotAllocation_expenseTransactionId_fkey`
+    FOREIGN KEY (`expenseTransactionId`) REFERENCES `Transaction`(`id`)
+    ON DELETE RESTRICT ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Historical cash withdrawal backfill.
+-- Linked records are created from clearly identifiable withdrawal transactions.
+-- Ambiguous matches are preserved as review-only records with zero values.
+INSERT INTO `CashLot` (
+  `userId`,
+  `withdrawalTransactionId`,
+  `withdrawalDate`,
+  `sourceAmount`,
+  `sourceCurrency`,
+  `destinationAmount`,
+  `destinationCurrency`,
+  `exchangeRate`,
+  `remainingAmount`,
+  `migrationStatus`,
+  `createdAt`,
+  `updatedAt`
+)
+SELECT
+  t.`userId`,
+  t.`id`,
+  t.`date`,
+  COALESCE(t.`amount`, 0),
+  'USD',
+  COALESCE(t.`originalCurrencyAmount`, 0),
+  UPPER(COALESCE(t.`currency`, 'USD')),
+  CASE
+    WHEN COALESCE(t.`amount`, 0) > 0 AND COALESCE(t.`originalCurrencyAmount`, 0) > 0 THEN COALESCE(t.`exchangeRateUsed`, t.`originalCurrencyAmount` / t.`amount`)
+    ELSE COALESCE(t.`exchangeRateUsed`, 1)
+  END,
+  COALESCE(t.`originalCurrencyAmount`, 0),
+  CASE
+    WHEN (
+      LOWER(COALESCE(t.`description`, '')) LIKE '%withdraw%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%withdrawal%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%atm%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%retiro%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%cash out%'
+      OR LOWER(COALESCE(t.`description`, '')) LIKE '%cash withdrawal%'
+    )
+    AND COALESCE(t.`amount`, 0) > 0
+    AND COALESCE(t.`originalCurrencyAmount`, 0) > 0
+    THEN 'linked'
+    ELSE 'unlinked'
+  END,
+  NOW(3),
+  NOW(3)
+FROM `Transaction` t
+LEFT JOIN `CashLot` c ON c.`withdrawalTransactionId` = t.`id`
+WHERE t.`type` = 'expense'
+  AND c.`id` IS NULL
+  AND (
+    LOWER(COALESCE(t.`description`, '')) LIKE '%withdraw%'
+    OR LOWER(COALESCE(t.`description`, '')) LIKE '%withdrawal%'
+    OR LOWER(COALESCE(t.`description`, '')) LIKE '%atm%'
+    OR LOWER(COALESCE(t.`description`, '')) LIKE '%retiro%'
+    OR LOWER(COALESCE(t.`description`, '')) LIKE '%cash out%'
+    OR LOWER(COALESCE(t.`description`, '')) LIKE '%cash withdrawal%'
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,8 @@ model User {
   budgetFallbackRules     BudgetFallbackRule[]
   budgetOverflowAssignments BudgetOverflowAssignment[]
   paymentMethods          PaymentMethod[]
+  cashLots                CashLot[]
+  cashLotAllocations      CashLotAllocation[]
   platformMonthlyRegister PlatformMonthlyRegister[]
   pushSubscriptions       PushSubscription[]
   shops                   Shop[]
@@ -173,12 +175,53 @@ model Transaction {
   paymentMethod          PaymentMethod? @relation(fields: [paymentMethodId], references: [id])
   shop                   Shop?          @relation(fields: [shopId], references: [id])
   user                   User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  cashLot                CashLot?       @relation("WithdrawalCashLot")
+  cashLotAllocations     CashLotAllocation[] @relation("ExpenseCashLotAllocations")
 
   @@unique([description, referenceId, date, userId])
   @@index([categoryId], map: "Transaction_categoryId_fkey")
   @@index([paymentMethodId], map: "Transaction_paymentMethodId_fkey")
   @@index([shopId], map: "Transaction_shopId_fkey")
   @@index([userId], map: "Transaction_userId_fkey")
+}
+
+model CashLot {
+  id                      Int                 @id @default(autoincrement())
+  userId                  Int
+  withdrawalTransactionId  Int?                @unique
+  withdrawalDate          DateTime
+  sourceAmount            Decimal             @db.Decimal(10, 2)
+  sourceCurrency          String              @db.VarChar(3)
+  destinationAmount       Decimal             @db.Decimal(10, 2)
+  destinationCurrency     String              @db.VarChar(3)
+  exchangeRate            Decimal             @db.Decimal(10, 6)
+  remainingAmount         Decimal             @db.Decimal(10, 2)
+  migrationStatus         String              @default("linked") @db.VarChar(20)
+  createdAt               DateTime            @default(now())
+  updatedAt               DateTime            @updatedAt
+  user                    User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  withdrawalTransaction   Transaction?        @relation("WithdrawalCashLot", fields: [withdrawalTransactionId], references: [id], onDelete: Restrict)
+  allocations             CashLotAllocation[]
+
+  @@index([userId], map: "CashLot_userId_fkey")
+  @@index([destinationCurrency, withdrawalDate], map: "CashLot_destinationCurrency_withdrawalDate_idx")
+}
+
+model CashLotAllocation {
+  id                  Int         @id @default(autoincrement())
+  userId              Int
+  cashLotId           Int
+  expenseTransactionId Int
+  allocatedAmount     Decimal     @db.Decimal(10, 2)
+  exchangeRate        Decimal     @db.Decimal(10, 6)
+  createdAt           DateTime    @default(now())
+  user                User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  cashLot             CashLot     @relation(fields: [cashLotId], references: [id], onDelete: Cascade)
+  expenseTransaction  Transaction @relation("ExpenseCashLotAllocations", fields: [expenseTransactionId], references: [id], onDelete: Restrict)
+
+  @@unique([cashLotId, expenseTransactionId], map: "cash_lot_allocation_uq")
+  @@index([userId], map: "CashLotAllocation_userId_fkey")
+  @@index([expenseTransactionId], map: "CashLotAllocation_expenseTransactionId_fkey")
 }
 
 model PlatformMonthlyRegister {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,6 +205,7 @@ model CashLot {
 
   @@index([userId], map: "CashLot_userId_fkey")
   @@index([destinationCurrency, withdrawalDate], map: "CashLot_destinationCurrency_withdrawalDate_idx")
+  @@index([userId, destinationCurrency, migrationStatus, withdrawalDate, id], map: "CashLot_user_dest_migration_withdrawal_id_idx")
 }
 
 model CashLotAllocation {

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -247,7 +247,7 @@ function mapTransactionResponse(tx: TransactionWithCashLots, fallbackCategory?: 
 					createdAt: allocation.createdAt.toISOString(),
 					cashLot: {
 						id: String(allocation.cashLot.id),
-						withdrawalDate: allocation.cashLot.withdrawalTransaction!.date.toISOString(),
+						withdrawalDate: allocation.cashLot.withdrawalTransaction?.date.toISOString() ?? null,
 						sourceAmount: Number(allocation.cashLot.sourceAmount ?? 0),
 						sourceCurrency: allocation.cashLot.sourceCurrency,
 						destinationAmount: Number(allocation.cashLot.destinationAmount ?? 0),
@@ -255,15 +255,17 @@ function mapTransactionResponse(tx: TransactionWithCashLots, fallbackCategory?: 
 						exchangeRate: Number(allocation.cashLot.exchangeRate ?? 0),
 						remainingAmount: Number(allocation.cashLot.remainingAmount ?? 0),
 						migrationStatus: allocation.cashLot.migrationStatus,
-						withdrawalTransaction: {
-							id: String(allocation.cashLot.withdrawalTransaction!.id),
-							date: allocation.cashLot.withdrawalTransaction!.date.toISOString(),
-							description: allocation.cashLot.withdrawalTransaction!.description ?? 'No description',
-							amount: Number(allocation.cashLot.withdrawalTransaction!.amount ?? 0),
-							currency: allocation.cashLot.withdrawalTransaction!.currency,
-							category: allocation.cashLot.withdrawalTransaction!.category?.name ?? 'Other',
-							paymentMethod: allocation.cashLot.withdrawalTransaction!.paymentMethod?.name ?? 'Other',
-						},
+						withdrawalTransaction: allocation.cashLot.withdrawalTransaction
+							? {
+									id: String(allocation.cashLot.withdrawalTransaction.id),
+									date: allocation.cashLot.withdrawalTransaction.date.toISOString(),
+									description: allocation.cashLot.withdrawalTransaction.description ?? 'No description',
+									amount: Number(allocation.cashLot.withdrawalTransaction.amount ?? 0),
+									currency: allocation.cashLot.withdrawalTransaction.currency,
+									category: allocation.cashLot.withdrawalTransaction.category?.name ?? 'Other',
+									paymentMethod: allocation.cashLot.withdrawalTransaction.paymentMethod?.name ?? 'Other',
+							  }
+							: null,
 					},
 				})),
 	};
@@ -893,6 +895,10 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 				: Number(cashWithdrawalDestinationAmount);
 
 		if (isCashWithdrawal) {
+			if (normalizedType !== 'debit') {
+				return res.status(400).json({ message: 'Withdrawal transactions must be registered as expenses' });
+			}
+
 			if (!paymentMethodId) {
 				return res.status(400).json({ message: 'Withdrawal requires a source payment method' });
 			}
@@ -1281,6 +1287,11 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			return res.status(400).json({ message: 'Missing required fields' });
 		}
 
+		const normalizedType = mapTransactionType(type);
+		if (!normalizedType) {
+			return res.status(400).json({ message: 'Missing or invalid required fields' });
+		}
+
 		let normalizedLocationMetadata;
 		try {
 			normalizedLocationMetadata = normalizeTransactionLocationMetadata({
@@ -1303,6 +1314,10 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			cashWithdrawalDestinationAmount === undefined || cashWithdrawalDestinationAmount === null
 				? null
 				: Number(cashWithdrawalDestinationAmount);
+
+		if (isCashWithdrawal && normalizedType !== 'debit') {
+			return res.status(400).json({ message: 'Withdrawal transactions must be registered as expenses' });
+		}
 
 		const updatedTransaction = await prisma.$transaction(async (tx) => {
 			const existingTransaction = await loadTransactionWithCashLots(tx, id, req.user.id);
@@ -1360,7 +1375,7 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 					description: description.trim(),
 					categoryId: matchedCategory.id,
 					paymentMethodId: resolvedPaymentMethodId,
-					type: type === 'income' ? 'credit' : 'debit',
+					type: normalizedType,
 					referenceId: referenceId?.trim() || null,
 					manualDescription: normalizedLocationMetadata.manualDescription,
 					locationName: normalizedLocationMetadata.locationName,

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -38,6 +38,8 @@ import { normalizeBudgetType, normalizeOptionalAmount, normalizeOptionalDueDay, 
 import { normalizeOptionalCoordinate, normalizeTransactionLocationMetadata } from '../src/lib/transaction-location';
 import { buildSharedMonthlySummary, createShareToken, isValidShareMonth } from '../src/lib/monthly-share-summary';
 import { createRedisRateLimitMiddleware } from '../src/lib/redis-rate-limit';
+import { CashLotServiceInstance } from '../modules/cash-lots/cash-lot.service';
+import { AppError } from '../src/lib/appError';
 
 const router = express.Router();
 const publicMonthlySummaryRateLimit = createRedisRateLimitMiddleware({
@@ -118,6 +120,167 @@ function normalizeCategoryKeyword(value: unknown): string | null {
 
 function isValidDate(value: Date): boolean {
 	return !Number.isNaN(value.getTime());
+}
+
+const transactionCashLotInclude = {
+	allocations: {
+		include: {
+			expenseTransaction: {
+				include: {
+					category: true,
+					paymentMethod: true,
+				},
+			},
+		},
+		orderBy: {
+			createdAt: 'asc' as const,
+		},
+	},
+	withdrawalTransaction: {
+		include: {
+			category: true,
+			paymentMethod: true,
+		},
+	},
+} as const;
+
+const transactionCashLotAllocationInclude = {
+	cashLot: {
+		include: {
+			withdrawalTransaction: {
+				include: {
+					category: true,
+					paymentMethod: true,
+				},
+			},
+		},
+	},
+} as const;
+
+const transactionWithCashLotsInclude = {
+	category: true,
+	paymentMethod: true,
+	cashLot: {
+		include: transactionCashLotInclude,
+	},
+	cashLotAllocations: {
+		include: transactionCashLotAllocationInclude,
+	},
+} as const;
+
+type TransactionWithCashLots = Prisma.TransactionGetPayload<{
+	include: typeof transactionWithCashLotsInclude;
+}>;
+
+function mapTransactionResponse(tx: TransactionWithCashLots, fallbackCategory?: string) {
+	const cashLot = tx.cashLot;
+
+	return {
+		id: String(tx.id),
+		date: tx.date.toISOString(),
+		description: tx.description ?? 'No description',
+		amount: Number(tx.amount ?? 0),
+		originalCurrencyAmount: Number(tx.originalCurrencyAmount ?? 0),
+		category: tx.category?.name ?? fallbackCategory ?? 'Other',
+		paymentMethod: tx.paymentMethod?.name ?? 'Other',
+		paymentMethodId: tx.paymentMethodId,
+		type: tx.type === 'credit' ? 'income' : 'expense',
+		source: 'manual',
+		referenceId: tx.referenceId ?? undefined,
+		manualDescription: tx.manualDescription ?? undefined,
+		locationName: tx.locationName ?? undefined,
+		latitude: tx.latitude === null ? undefined : Number(tx.latitude),
+		longitude: tx.longitude === null ? undefined : Number(tx.longitude),
+		googleMapsUrl: tx.googleMapsUrl ?? undefined,
+		currency: tx.currency,
+		exchangeRateUsed: tx.exchangeRateUsed === null ? undefined : Number(tx.exchangeRateUsed),
+		exchangeRateSource: tx.exchangeRateSource ?? undefined,
+		exchangeRateSourceKey: tx.exchangeRateSourceKey ?? undefined,
+		reviewed: tx.reviewed,
+		cashLot: cashLot
+			? {
+					id: String(cashLot.id),
+					withdrawalTransactionId: cashLot.withdrawalTransactionId === null ? null : String(cashLot.withdrawalTransactionId),
+					withdrawalDate: cashLot.withdrawalDate.toISOString(),
+					sourceAmount: Number(cashLot.sourceAmount ?? 0),
+					sourceCurrency: cashLot.sourceCurrency,
+					destinationAmount: Number(cashLot.destinationAmount ?? 0),
+					destinationCurrency: cashLot.destinationCurrency,
+					exchangeRate: Number(cashLot.exchangeRate ?? 0),
+					remainingAmount: Number(cashLot.remainingAmount ?? 0),
+					migrationStatus: cashLot.migrationStatus,
+					createdAt: cashLot.createdAt.toISOString(),
+					updatedAt: cashLot.updatedAt.toISOString(),
+					allocations: cashLot.allocations.map((allocation) => ({
+						id: String(allocation.id),
+						cashLotId: String(allocation.cashLotId),
+						expenseTransactionId: String(allocation.expenseTransactionId),
+						allocatedAmount: Number(allocation.allocatedAmount ?? 0),
+						exchangeRate: Number(allocation.exchangeRate ?? 0),
+						sourceEquivalentAmount:
+							Number(allocation.exchangeRate ?? 0) > 0
+								? Math.round((Number(allocation.allocatedAmount ?? 0) / Number(allocation.exchangeRate ?? 0)) * 100) / 100
+								: 0,
+						createdAt: allocation.createdAt.toISOString(),
+						expenseTransaction: {
+							id: String(allocation.expenseTransaction.id),
+							date: allocation.expenseTransaction.date.toISOString(),
+							description: allocation.expenseTransaction.description ?? 'No description',
+							amount: Number(allocation.expenseTransaction.amount ?? 0),
+							currency: allocation.expenseTransaction.currency,
+							category: allocation.expenseTransaction.category?.name ?? 'Other',
+							paymentMethod: allocation.expenseTransaction.paymentMethod?.name ?? 'Other',
+						},
+					})),
+				}
+			: undefined,
+				cashLotAllocations: tx.cashLotAllocations.map((allocation) => ({
+					id: String(allocation.id),
+					cashLotId: String(allocation.cashLotId),
+					expenseTransactionId: String(allocation.expenseTransactionId),
+					allocatedAmount: Number(allocation.allocatedAmount ?? 0),
+					exchangeRate: Number(allocation.exchangeRate ?? 0),
+					sourceEquivalentAmount:
+						Number(allocation.exchangeRate ?? 0) > 0
+							? Math.round((Number(allocation.allocatedAmount ?? 0) / Number(allocation.exchangeRate ?? 0)) * 100) / 100
+							: 0,
+					createdAt: allocation.createdAt.toISOString(),
+					cashLot: {
+						id: String(allocation.cashLot.id),
+						withdrawalDate: allocation.cashLot.withdrawalTransaction!.date.toISOString(),
+						sourceAmount: Number(allocation.cashLot.sourceAmount ?? 0),
+						sourceCurrency: allocation.cashLot.sourceCurrency,
+						destinationAmount: Number(allocation.cashLot.destinationAmount ?? 0),
+						destinationCurrency: allocation.cashLot.destinationCurrency,
+						exchangeRate: Number(allocation.cashLot.exchangeRate ?? 0),
+						remainingAmount: Number(allocation.cashLot.remainingAmount ?? 0),
+						migrationStatus: allocation.cashLot.migrationStatus,
+						withdrawalTransaction: {
+							id: String(allocation.cashLot.withdrawalTransaction!.id),
+							date: allocation.cashLot.withdrawalTransaction!.date.toISOString(),
+							description: allocation.cashLot.withdrawalTransaction!.description ?? 'No description',
+							amount: Number(allocation.cashLot.withdrawalTransaction!.amount ?? 0),
+							currency: allocation.cashLot.withdrawalTransaction!.currency,
+							category: allocation.cashLot.withdrawalTransaction!.category?.name ?? 'Other',
+							paymentMethod: allocation.cashLot.withdrawalTransaction!.paymentMethod?.name ?? 'Other',
+						},
+					},
+				})),
+	};
+}
+
+async function loadTransactionWithCashLots(
+	db: Prisma.TransactionClient | typeof prisma,
+	transactionId: number,
+	userId: number
+): Promise<TransactionWithCashLots | null> {
+	return db.transaction.findFirst({
+		where: {
+			id: transactionId,
+			userId,
+		},
+		include: transactionWithCashLotsInclude,
+	});
 }
 
 function pickBestKeywordCategory(
@@ -597,35 +760,10 @@ router.get('/api/transactions', requireAuth, async (req: Request, res: Response)
 				paymentMethodId: paymentMethodId ? Number(paymentMethodId) : undefined,
 			},
 			orderBy: { date: 'desc' },
-			include: { 
-				category: true,
-				paymentMethod: true,
-			},
+			include: transactionWithCashLotsInclude,
 		});
 
-		const mapped = transactions.map((tx) => ({
-			id: String(tx.id),
-			date: tx.date.toISOString(),
-			description: tx.description ?? 'No description',
-			amount: Number(tx.amount ?? 0),
-			originalCurrencyAmount: Number(tx.originalCurrencyAmount ?? 0),
-			category: tx.category?.name ?? 'Other',
-			paymentMethod: tx.paymentMethod?.name ?? 'Other',
-			paymentMethodId: tx.paymentMethodId,
-			type: tx.type === 'credit' ? 'income' : 'expense',
-			source: 'manual',
-			referenceId: tx.referenceId ?? undefined,
-			manualDescription: tx.manualDescription ?? undefined,
-			locationName: tx.locationName ?? undefined,
-			latitude: tx.latitude === null ? undefined : Number(tx.latitude),
-			longitude: tx.longitude === null ? undefined : Number(tx.longitude),
-			googleMapsUrl: tx.googleMapsUrl ?? undefined,
-			currency: tx.currency,
-			exchangeRateUsed: tx.exchangeRateUsed === null ? undefined : Number(tx.exchangeRateUsed),
-			exchangeRateSource: tx.exchangeRateSource ?? undefined,
-			exchangeRateSourceKey: tx.exchangeRateSourceKey ?? undefined,
-			reviewed: tx.reviewed,
-		}));
+		const mapped = transactions.map((tx) => mapTransactionResponse(tx));
 
 		res.status(200).json(mapped);
 	} catch (error) {
@@ -682,7 +820,25 @@ router.get('/api/exchange-rates/latest', requireAuth, async (req: Request, res: 
 
 router.post('/api/transactions', requireAuth, async (req: Request, res: Response) => {
 	try {
-		const { date, description, amount, category, type, paymentMethodId, currency, manualDescription, locationName, latitude, longitude, googleMapsUrl, exchangeRateOverride } = req.body as {
+		const {
+			date,
+			description,
+			amount,
+			category,
+			type,
+			paymentMethodId,
+			currency,
+			manualDescription,
+			locationName,
+			latitude,
+			longitude,
+			googleMapsUrl,
+			exchangeRateOverride,
+			isCashWithdrawal,
+			cashWithdrawalDestinationAmount,
+			cashWithdrawalDestinationCurrency,
+			cashWithdrawalExchangeRate,
+		} = req.body as {
 			date?: string;
 			description?: string;
 			amount?: number;
@@ -696,6 +852,10 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			longitude?: number;
 			googleMapsUrl?: string;
 			exchangeRateOverride?: number;
+			isCashWithdrawal?: boolean;
+			cashWithdrawalDestinationAmount?: number;
+			cashWithdrawalDestinationCurrency?: string;
+			cashWithdrawalExchangeRate?: number;
 		};
 
 
@@ -721,6 +881,43 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			});
 		}
 
+		const normalizedCashWithdrawalDestinationCurrency =
+			typeof cashWithdrawalDestinationCurrency === 'string' ? cashWithdrawalDestinationCurrency.trim().toUpperCase() : '';
+		const normalizedCashWithdrawalExchangeRate =
+			cashWithdrawalExchangeRate === undefined || cashWithdrawalExchangeRate === null
+				? null
+				: Number(cashWithdrawalExchangeRate);
+		const normalizedCashWithdrawalDestinationAmount =
+			cashWithdrawalDestinationAmount === undefined || cashWithdrawalDestinationAmount === null
+				? null
+				: Number(cashWithdrawalDestinationAmount);
+
+		if (isCashWithdrawal) {
+			if (!paymentMethodId) {
+				return res.status(400).json({ message: 'Withdrawal requires a source payment method' });
+			}
+
+			if (
+				!normalizedCashWithdrawalDestinationCurrency ||
+				!Number.isFinite(normalizedCashWithdrawalExchangeRate) ||
+				normalizedCashWithdrawalExchangeRate === null ||
+				normalizedCashWithdrawalExchangeRate <= 0
+			) {
+				return res.status(400).json({
+					message: 'Withdrawal destination currency and exchange rate are required',
+				});
+			}
+
+			if (
+				normalizedCashWithdrawalDestinationAmount !== null &&
+				(!Number.isFinite(normalizedCashWithdrawalDestinationAmount) || normalizedCashWithdrawalDestinationAmount <= 0)
+			) {
+				return res.status(400).json({
+					message: 'Withdrawal destination amount must be a positive number when provided',
+				});
+			}
+		}
+
 		// 1. Match Category
 		const matchedCategory = await prisma.category.findFirst({
 			where: { name: category, userId: req.user.id },
@@ -738,6 +935,10 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 				return res.status(400).json({ message: 'Invalid payment method' });
 			}
 		} else {
+			if (isCashWithdrawal) {
+				return res.status(400).json({ message: 'Withdrawal requires a source payment method' });
+			}
+
 			// Fallback to "Cash"
 			let cashMethod = await prisma.paymentMethod.findFirst({
 				where: { name: 'Cash', userId: req.user.id }
@@ -751,48 +952,73 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 		}
 
 		// 3. Handle Creation via Gatekeeper (Deduplication & Normalization)
-		const { transaction } = await BaseTransactions.safeCreateTransaction({
-			userId: req.user.id,
-			date: new Date(date),
-			description,
-			amount,
-			currency: currency || 'USD',
-			type: normalizedType,
-			categoryId: matchedCategory?.id,
-			paymentMethodId: finalPaymentMethodId,
-			manualDescription: normalizedLocationMetadata.manualDescription,
-			locationName: normalizedLocationMetadata.locationName,
-			latitude: normalizeOptionalCoordinate(latitude),
-			longitude: normalizeOptionalCoordinate(longitude),
-			googleMapsUrl: normalizedLocationMetadata.googleMapsUrl,
-			exchangeRateOverride,
-			reviewed: true,
+		const createdTransaction = await prisma.$transaction(async (tx) => {
+			const { transaction, isDuplicate } = await BaseTransactions.safeCreateTransaction(
+				{
+					userId: req.user.id,
+					date: new Date(date),
+					description,
+					amount,
+					currency: currency || 'USD',
+					type: normalizedType,
+					categoryId: matchedCategory?.id,
+					paymentMethodId: finalPaymentMethodId,
+					manualDescription: normalizedLocationMetadata.manualDescription,
+					locationName: normalizedLocationMetadata.locationName,
+					latitude: normalizeOptionalCoordinate(latitude),
+					longitude: normalizeOptionalCoordinate(longitude),
+					googleMapsUrl: normalizedLocationMetadata.googleMapsUrl,
+					exchangeRateOverride,
+					reviewed: true,
+				},
+				tx
+			);
+
+			if (isDuplicate) {
+				const duplicateTransaction = await loadTransactionWithCashLots(tx, transaction.id, req.user.id);
+				return duplicateTransaction;
+			}
+
+			if (isCashWithdrawal) {
+				const destinationAmount =
+					normalizedCashWithdrawalDestinationAmount ??
+					Math.round(Number(amount) * Number(normalizedCashWithdrawalExchangeRate) * 100) / 100;
+
+				await CashLotServiceInstance.createWithdrawalCashLot(
+					transaction,
+					{
+						destinationAmount,
+						destinationCurrency: normalizedCashWithdrawalDestinationCurrency,
+						exchangeRate: Number(normalizedCashWithdrawalExchangeRate),
+						migrationStatus: 'linked',
+					},
+					tx
+				);
+			} else {
+				const paymentMethod = await tx.paymentMethod.findFirst({
+					where: {
+						id: finalPaymentMethodId ?? undefined,
+						userId: req.user.id,
+					},
+				});
+
+				if (normalizedType === 'debit' && paymentMethod?.name === 'Cash') {
+					await CashLotServiceInstance.allocateCashExpense(transaction, tx);
+				}
+			}
+
+			return loadTransactionWithCashLots(tx, transaction.id, req.user.id);
 		});
 
-		res.status(201).json({
-			id: String(transaction.id),
-			date: transaction.date.toISOString(),
-			description: transaction.description ?? 'No description',
-			amount: Number(transaction.amount ?? 0),
-			originalCurrencyAmount: Number(transaction.originalCurrencyAmount ?? 0),
-			currency: transaction.currency,
-			category: transaction.category?.name ?? category,
-			paymentMethod: transaction.paymentMethod?.name ?? 'Other',
-			paymentMethodId: transaction.paymentMethodId,
-			type,
-			source: 'manual',
-			referenceId: transaction.referenceId ?? undefined,
-			manualDescription: transaction.manualDescription ?? undefined,
-			locationName: transaction.locationName ?? undefined,
-			latitude: transaction.latitude === null ? undefined : Number(transaction.latitude),
-			longitude: transaction.longitude === null ? undefined : Number(transaction.longitude),
-			googleMapsUrl: transaction.googleMapsUrl ?? undefined,
-			reviewed: transaction.reviewed,
-			exchangeRateUsed: transaction.exchangeRateUsed === null ? undefined : Number(transaction.exchangeRateUsed),
-			exchangeRateSource: transaction.exchangeRateSource ?? undefined,
-			exchangeRateSourceKey: transaction.exchangeRateSourceKey ?? undefined,
-		});
+		if (!createdTransaction) {
+			return res.status(500).json({ message: 'Failed to create transaction' });
+		}
+
+		res.status(201).json(mapTransactionResponse(createdTransaction, category));
 	} catch (error) {
+		if (error instanceof AppError) {
+			return res.status(error.statusCode).json({ message: error.message });
+		}
 		logger.error('Failed to create transaction', { error, userId: req.user.id });
 		res.status(500).json({ message: 'Failed to create transaction' });
 	}
@@ -967,12 +1193,35 @@ router.delete('/api/transactions/:id', requireAuth, async (req: Request, res: Re
 			return res.status(400).json({ message: 'Invalid transaction id' });
 		}
 
-		await prisma.transaction.deleteMany({
-			where: { id, userId: req.user.id },
+		const existingTransaction = await loadTransactionWithCashLots(prisma, id, req.user.id);
+		if (!existingTransaction) {
+			return res.status(404).json({ message: 'Transaction not found' });
+		}
+
+		await prisma.$transaction(async (tx) => {
+			const transaction = await loadTransactionWithCashLots(tx, id, req.user.id);
+			if (!transaction) {
+				throw new AppError('Transaction not found', 404);
+			}
+
+			if (transaction.cashLot) {
+				await CashLotServiceInstance.deleteWithdrawalCashLot(transaction.id, req.user.id, tx);
+			}
+
+			if (transaction.cashLotAllocations.length > 0) {
+				await CashLotServiceInstance.restoreExpenseAllocations(transaction.id, req.user.id, tx);
+			}
+
+			await tx.transaction.delete({
+				where: { id: transaction.id },
+			});
 		});
 
 		res.status(204).send();
 	} catch (error) {
+		if (error instanceof AppError) {
+			return res.status(error.statusCode).json({ message: error.message });
+		}
 		res.status(500).json({ message: 'Failed to delete transaction' });
 	}
 });
@@ -995,6 +1244,10 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			longitude,
 			googleMapsUrl,
 			exchangeRateOverride,
+			isCashWithdrawal,
+			cashWithdrawalDestinationAmount,
+			cashWithdrawalDestinationCurrency,
+			cashWithdrawalExchangeRate,
 		} = req.body as {
 			date?: string;
 			description?: string;
@@ -1010,6 +1263,10 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 			longitude?: number | null;
 			googleMapsUrl?: string;
 			exchangeRateOverride?: number | null;
+			isCashWithdrawal?: boolean;
+			cashWithdrawalDestinationAmount?: number | null;
+			cashWithdrawalDestinationCurrency?: string;
+			cashWithdrawalExchangeRate?: number | null;
 		};
 
 		if (
@@ -1036,102 +1293,155 @@ router.patch('/api/transactions/:id', requireAuth, async (req: Request, res: Res
 				message: error instanceof Error ? error.message : 'Invalid location metadata',
 			});
 		}
+		const normalizedCashWithdrawalDestinationCurrency =
+			typeof cashWithdrawalDestinationCurrency === 'string' ? cashWithdrawalDestinationCurrency.trim().toUpperCase() : '';
+		const normalizedCashWithdrawalExchangeRate =
+			cashWithdrawalExchangeRate === undefined || cashWithdrawalExchangeRate === null
+				? null
+				: Number(cashWithdrawalExchangeRate);
+		const normalizedCashWithdrawalDestinationAmount =
+			cashWithdrawalDestinationAmount === undefined || cashWithdrawalDestinationAmount === null
+				? null
+				: Number(cashWithdrawalDestinationAmount);
 
-		const existingTransaction = await prisma.transaction.findFirst({
-			where: { id, userId: req.user.id },
-		});
+		const updatedTransaction = await prisma.$transaction(async (tx) => {
+			const existingTransaction = await loadTransactionWithCashLots(tx, id, req.user.id);
+			if (!existingTransaction) {
+				throw new AppError('Transaction not found', 404);
+			}
 
-		if (!existingTransaction) {
-			return res.status(404).json({ message: 'Transaction not found' });
-		}
-
-		let matchedCategory = await prisma.category.findFirst({
-			where: { name: category.trim(), userId: req.user.id },
-		});
-
-		if (!matchedCategory) {
-			matchedCategory = await prisma.category.create({
-				data: { name: category.trim(), userId: req.user.id },
+			let matchedCategory = await tx.category.findFirst({
+				where: { name: category.trim(), userId: req.user.id },
 			});
-		}
 
-		const resolvedPaymentMethodId =
-			typeof paymentMethodId === 'number' && Number.isFinite(paymentMethodId) && paymentMethodId > 0
-				? paymentMethodId
+			if (!matchedCategory) {
+				matchedCategory = await tx.category.create({
+					data: { name: category.trim(), userId: req.user.id },
+				});
+			}
+
+			const resolvedPaymentMethodId =
+				typeof paymentMethodId === 'number' && Number.isFinite(paymentMethodId) && paymentMethodId > 0
+					? paymentMethodId
+					: existingTransaction.paymentMethodId;
+
+			if (resolvedPaymentMethodId) {
+				const paymentMethod = await tx.paymentMethod.findFirst({
+					where: { id: resolvedPaymentMethodId, userId: req.user.id },
+				});
+
+				if (!paymentMethod) {
+					throw new AppError('Payment method not found', 404);
+				}
+			}
+
+			const currentPaymentMethod = resolvedPaymentMethodId
+				? await tx.paymentMethod.findFirst({
+						where: { id: resolvedPaymentMethodId, userId: req.user.id },
+				  })
 				: null;
 
-		if (resolvedPaymentMethodId) {
-			const paymentMethod = await prisma.paymentMethod.findFirst({
-				where: { id: resolvedPaymentMethodId, userId: req.user.id },
+			const normalizedLatitude = normalizeOptionalCoordinate(latitude);
+			const normalizedLongitude = normalizeOptionalCoordinate(longitude);
+			const normalizedAmounts = await BaseTransactions.normalizeTransactionAmount({
+				amount: Number(amount),
+				currency: currency.trim().toUpperCase(),
+				date: new Date(date),
+				exchangeRateOverride,
 			});
 
-			if (!paymentMethod) {
-				return res.status(404).json({ message: 'Payment method not found' });
+			const updated = await tx.transaction.update({
+				where: { id: existingTransaction.id },
+				data: {
+					amount: normalizedAmounts.amount,
+					currency: normalizedAmounts.currency,
+					originalCurrencyAmount: normalizedAmounts.originalCurrencyAmount,
+					date: new Date(date),
+					description: description.trim(),
+					categoryId: matchedCategory.id,
+					paymentMethodId: resolvedPaymentMethodId,
+					type: type === 'income' ? 'credit' : 'debit',
+					referenceId: referenceId?.trim() || null,
+					manualDescription: normalizedLocationMetadata.manualDescription,
+					locationName: normalizedLocationMetadata.locationName,
+					latitude: normalizedLatitude,
+					longitude: normalizedLongitude,
+					googleMapsUrl: normalizedLocationMetadata.googleMapsUrl,
+					exchangeRateUsed: normalizedAmounts.exchangeRateUsed,
+					exchangeRateSource: normalizedAmounts.exchangeRateSource,
+					exchangeRateSourceKey: normalizedAmounts.exchangeRateSourceKey,
+					reviewed: true,
+					reviewedAt: new Date(),
+				},
+				include: transactionWithCashLotsInclude,
+			});
+
+			if (existingTransaction.cashLotAllocations.length > 0) {
+				await CashLotServiceInstance.restoreExpenseAllocations(existingTransaction.id, req.user.id, tx);
 			}
+
+			const shouldMaintainWithdrawalCashLot =
+				Boolean(existingTransaction.cashLot) || Boolean(isCashWithdrawal);
+
+			if (shouldMaintainWithdrawalCashLot) {
+				if (
+					!normalizedCashWithdrawalDestinationCurrency &&
+					!existingTransaction.cashLot &&
+					!isCashWithdrawal
+				) {
+					throw new AppError('Withdrawal destination currency is required', 400);
+				}
+
+				const withdrawalDestinationAmount =
+					normalizedCashWithdrawalDestinationAmount ??
+					(Math.round(Number(amount) * Number(
+						normalizedCashWithdrawalExchangeRate ??
+							(existingTransaction.cashLot ? Number(existingTransaction.cashLot.exchangeRate ?? 0) : 0)
+					) * 100) / 100);
+				const withdrawalDestinationCurrency =
+					normalizedCashWithdrawalDestinationCurrency ||
+					(existingTransaction.cashLot ? existingTransaction.cashLot.destinationCurrency : '');
+				const withdrawalExchangeRate =
+					normalizedCashWithdrawalExchangeRate ??
+					(existingTransaction.cashLot ? Number(existingTransaction.cashLot.exchangeRate ?? 0) : null);
+
+				if (
+					!Number.isFinite(withdrawalDestinationAmount) ||
+					withdrawalDestinationAmount <= 0 ||
+					!withdrawalDestinationCurrency ||
+					!Number.isFinite(withdrawalExchangeRate) ||
+					withdrawalExchangeRate === null ||
+					withdrawalExchangeRate <= 0
+				) {
+					throw new AppError('Withdrawal destination amount, currency and exchange rate are required', 400);
+				}
+
+				await CashLotServiceInstance.updateWithdrawalCashLot(
+					updated,
+					{
+						destinationAmount: withdrawalDestinationAmount,
+						destinationCurrency: withdrawalDestinationCurrency,
+						exchangeRate: withdrawalExchangeRate,
+						migrationStatus: existingTransaction.cashLot?.migrationStatus === 'unlinked' ? 'unlinked' : 'linked',
+					},
+					tx
+				);
+			} else if (type === 'expense' && currentPaymentMethod?.name === 'Cash') {
+				await CashLotServiceInstance.allocateCashExpense(updated, tx);
+			}
+
+			return loadTransactionWithCashLots(tx, updated.id, req.user.id);
+		});
+
+		if (!updatedTransaction) {
+			return res.status(500).json({ message: 'Failed to update transaction' });
 		}
 
-		const normalizedLatitude = normalizeOptionalCoordinate(latitude);
-		const normalizedLongitude = normalizeOptionalCoordinate(longitude);
-		const normalizedAmounts = await BaseTransactions.normalizeTransactionAmount({
-			amount: Number(amount),
-			currency: currency.trim().toUpperCase(),
-			date: new Date(date),
-			exchangeRateOverride,
-		});
-
-		const updated = await prisma.transaction.update({
-			where: { id: existingTransaction.id },
-			data: {
-				amount: normalizedAmounts.amount,
-				currency: normalizedAmounts.currency,
-				originalCurrencyAmount: normalizedAmounts.originalCurrencyAmount,
-				date: new Date(date),
-				description: description.trim(),
-				categoryId: matchedCategory.id,
-				paymentMethodId: resolvedPaymentMethodId,
-				type: type === 'income' ? 'credit' : 'debit',
-				referenceId: referenceId?.trim() || null,
-				manualDescription: normalizedLocationMetadata.manualDescription,
-				locationName: normalizedLocationMetadata.locationName,
-				latitude: normalizedLatitude,
-				longitude: normalizedLongitude,
-				googleMapsUrl: normalizedLocationMetadata.googleMapsUrl,
-				exchangeRateUsed: normalizedAmounts.exchangeRateUsed,
-				exchangeRateSource: normalizedAmounts.exchangeRateSource,
-				exchangeRateSourceKey: normalizedAmounts.exchangeRateSourceKey,
-				reviewed: true,
-				reviewedAt: new Date(),
-			},
-			include: {
-				category: true,
-				paymentMethod: true,
-			},
-		});
-
-		return res.status(200).json({
-			id: String(updated.id),
-			date: updated.date.toISOString(),
-			description: updated.description ?? 'No description',
-			amount: Number(updated.amount ?? 0),
-			originalCurrencyAmount: Number(updated.originalCurrencyAmount ?? 0),
-			category: updated.category?.name ?? category,
-			paymentMethod: updated.paymentMethod?.name ?? 'Other',
-			paymentMethodId: updated.paymentMethodId,
-			type: updated.type === 'credit' ? 'income' : 'expense',
-			source: 'manual',
-			referenceId: updated.referenceId ?? undefined,
-			manualDescription: updated.manualDescription ?? undefined,
-			locationName: updated.locationName ?? undefined,
-			latitude: updated.latitude === null ? undefined : Number(updated.latitude),
-			longitude: updated.longitude === null ? undefined : Number(updated.longitude),
-			googleMapsUrl: updated.googleMapsUrl ?? undefined,
-			currency: updated.currency,
-			exchangeRateUsed: updated.exchangeRateUsed === null ? undefined : Number(updated.exchangeRateUsed),
-			exchangeRateSource: updated.exchangeRateSource ?? undefined,
-			exchangeRateSourceKey: updated.exchangeRateSourceKey ?? undefined,
-			reviewed: updated.reviewed,
-		});
+		return res.status(200).json(mapTransactionResponse(updatedTransaction, category));
 	} catch (error) {
+		if (error instanceof AppError) {
+			return res.status(error.statusCode).json({ message: error.message });
+		}
 		logger.error('Failed to update transaction', { error, userId: req.user.id });
 		return res.status(500).json({ message: 'Failed to update transaction' });
 	}

--- a/src/lib/monthly-share-summary.ts
+++ b/src/lib/monthly-share-summary.ts
@@ -73,6 +73,9 @@ export async function buildSharedMonthlySummary(userId: number, month: number, y
           gte: startDate,
           lt: endDate,
         },
+        cashLot: {
+          is: null,
+        },
       },
       include: {
         category: true,

--- a/tests/transaction-crud.test.ts
+++ b/tests/transaction-crud.test.ts
@@ -6,6 +6,8 @@ import { prismaMock } from '../modules/database/database.module.mock';
 import { createCategory, createKeyword, createPaymentMethod, createTransaction, createUser } from '../prisma/factories';
 import { Decimal } from '@prisma/client/runtime/library';
 import { requireAuth } from '../src/lib/auth.middleware';
+import { BaseTransactions } from '../modules/base-transactions/base-transactions.module';
+import { CashLotServiceInstance } from '../modules/cash-lots/cash-lot.service';
 
 // Mock the auth middleware
 jest.mock('../src/lib/auth.middleware', () => {
@@ -22,9 +24,39 @@ jest.mock('../src/lib/auth.middleware', () => {
 	};
 });
 
+jest.mock('../modules/cash-lots/cash-lot.service', () => ({
+	CashLotServiceInstance: {
+		createWithdrawalCashLot: jest.fn(),
+		updateWithdrawalCashLot: jest.fn(),
+		allocateCashExpense: jest.fn(),
+		restoreExpenseAllocations: jest.fn(),
+		deleteWithdrawalCashLot: jest.fn(),
+		getWithdrawalLotByTransactionId: jest.fn(),
+		getExpenseAllocations: jest.fn(),
+	},
+}));
+
+const cashLotServiceMock = CashLotServiceInstance as unknown as {
+	createWithdrawalCashLot: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+	updateWithdrawalCashLot: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+	allocateCashExpense: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+	restoreExpenseAllocations: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+	deleteWithdrawalCashLot: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+	getWithdrawalLotByTransactionId: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+	getExpenseAllocations: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+};
+
 describe('Transaction API (CRUD)', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		jest.restoreAllMocks();
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) => {
+			if (typeof callback !== 'function') {
+				throw new Error('Expected transaction callback');
+			}
+
+			return callback(prismaMock as never);
+		});
 	});
 
 	// TDD Scenario 1: Unauthorized POST /api/transactions
@@ -47,7 +79,13 @@ describe('Transaction API (CRUD)', () => {
 		const tx1 = await createTransaction({ id: 1, userId: user1.id, description: 'My Transaction' });
 
 		// Mock the database to return only the filtered transactions
-		prismaMock.transaction.findMany.mockResolvedValue([tx1]);
+		prismaMock.transaction.findMany.mockResolvedValue([
+			{
+				...tx1,
+				cashLot: null,
+				cashLotAllocations: [],
+			} as never,
+		] as never);
 
 		const response = await request(app).get('/api/transactions');
 		
@@ -535,5 +573,354 @@ describe('Transaction API (CRUD)', () => {
 		expect(response.body).toEqual({ message: 'locationName must be 255 characters or fewer' });
 		expect(prismaMock.transaction.findFirst).not.toHaveBeenCalled();
 		expect(prismaMock.transaction.update).not.toHaveBeenCalled();
+	});
+
+	it('should create a cash lot when posting a withdrawal transaction', async () => {
+		const category = createCategory({ id: 30, userId: 1, name: 'Cash Withdrawal' } as never);
+		const paymentMethod = createPaymentMethod({ id: 40, userId: 1, name: 'Bank Account' } as never);
+		const withdrawalTransaction = createTransaction({
+			id: 301,
+			userId: 1,
+			description: 'ATM withdrawal',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+			currency: 'USD',
+			type: 'debit',
+			paymentMethodId: paymentMethod.id,
+			categoryId: category.id,
+		} as never);
+		const withdrawalLot = {
+			id: 1,
+			withdrawalTransactionId: withdrawalTransaction.id,
+			withdrawalDate: withdrawalTransaction.date,
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(120000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			allocations: [],
+			withdrawalTransaction: {
+				...withdrawalTransaction,
+				category,
+				paymentMethod,
+			},
+		};
+
+		prismaMock.category.findFirst.mockResolvedValue(category);
+		prismaMock.paymentMethod.findFirst.mockResolvedValue(paymentMethod);
+		jest.spyOn(BaseTransactions, 'safeCreateTransaction').mockResolvedValue({
+			transaction: withdrawalTransaction,
+			isDuplicate: false,
+		} as never);
+		cashLotServiceMock.createWithdrawalCashLot.mockResolvedValue(withdrawalLot);
+		prismaMock.transaction.findFirst.mockResolvedValueOnce({
+			...withdrawalTransaction,
+			category,
+			paymentMethod,
+			cashLot: withdrawalLot,
+			cashLotAllocations: [],
+		} as never);
+
+		const response = await request(app).post('/api/transactions').send({
+			date: '2026-04-01',
+			description: 'ATM withdrawal',
+			amount: 100,
+			category: 'Cash Withdrawal',
+			type: 'expense',
+			paymentMethodId: paymentMethod.id,
+			currency: 'USD',
+			isCashWithdrawal: true,
+			cashWithdrawalDestinationAmount: 120000,
+			cashWithdrawalDestinationCurrency: 'ARS',
+			cashWithdrawalExchangeRate: 1200,
+		});
+
+		expect(response.status).toBe(201);
+		expect(response.body).toMatchObject({
+			id: '301',
+			type: 'expense',
+			cashLot: {
+				destinationAmount: 120000,
+				destinationCurrency: 'ARS',
+				exchangeRate: 1200,
+				remainingAmount: 120000,
+			},
+		});
+		expect(cashLotServiceMock.createWithdrawalCashLot).toHaveBeenCalledTimes(1);
+		expect(cashLotServiceMock.createWithdrawalCashLot.mock.calls[0]?.[0]).toMatchObject({
+			id: withdrawalTransaction.id,
+			description: withdrawalTransaction.description,
+			currency: withdrawalTransaction.currency,
+		});
+		expect(cashLotServiceMock.createWithdrawalCashLot.mock.calls[0]?.[1]).toEqual({
+			destinationAmount: 120000,
+			destinationCurrency: 'ARS',
+			exchangeRate: 1200,
+			migrationStatus: 'linked',
+		});
+	});
+
+	it('should allocate cash expenses from available cash lots', async () => {
+		const category = createCategory({ id: 31, userId: 1, name: 'Food' } as never);
+		const paymentMethod = createPaymentMethod({ id: 41, userId: 1, name: 'Cash' } as never);
+		const expenseTransaction = createTransaction({
+			id: 302,
+			userId: 1,
+			description: 'Lunch',
+			amount: new Decimal(20000),
+			originalCurrencyAmount: new Decimal(20000),
+			currency: 'ARS',
+			type: 'debit',
+			categoryId: category.id,
+			paymentMethodId: paymentMethod.id,
+		} as never);
+		const withdrawalLot = {
+			id: 8,
+			withdrawalTransactionId: 201,
+			withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(100000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			allocations: [],
+			withdrawalTransaction: {
+				id: 201,
+				date: new Date('2026-04-01T10:00:00.000Z'),
+				description: 'ATM withdrawal',
+				amount: 100,
+				currency: 'USD',
+				category: { name: 'Other' },
+				paymentMethod: { name: 'Bank Account' },
+			},
+		};
+
+		prismaMock.category.findFirst.mockResolvedValue(category);
+		prismaMock.paymentMethod.findFirst.mockResolvedValue(paymentMethod);
+		jest.spyOn(BaseTransactions, 'safeCreateTransaction').mockResolvedValue({
+			transaction: expenseTransaction,
+			isDuplicate: false,
+		} as never);
+		cashLotServiceMock.allocateCashExpense.mockResolvedValue({
+			allocations: [
+				{
+					cashLotId: withdrawalLot.id,
+					allocatedAmount: 20000,
+					exchangeRate: 1200,
+					sourceEquivalentAmount: 16.67,
+				},
+			],
+			totalAllocated: 20000,
+		});
+		prismaMock.transaction.findFirst.mockResolvedValueOnce({
+			...expenseTransaction,
+			category,
+			paymentMethod,
+			cashLot: null,
+			cashLotAllocations: [
+				{
+					id: 1,
+					cashLotId: withdrawalLot.id,
+					expenseTransactionId: expenseTransaction.id,
+					allocatedAmount: new Decimal(20000),
+					exchangeRate: new Decimal(1200),
+					sourceEquivalentAmount: 16.67,
+					createdAt: new Date('2026-04-02T12:00:00.000Z'),
+					cashLot: withdrawalLot,
+				},
+			],
+		} as never);
+
+		const response = await request(app).post('/api/transactions').send({
+			date: '2026-04-02',
+			description: 'Lunch',
+			amount: 20000,
+			category: 'Food',
+			type: 'expense',
+			paymentMethodId: paymentMethod.id,
+			currency: 'ARS',
+		});
+
+		expect(response.status).toBe(201);
+		expect(response.body.cashLotAllocations).toHaveLength(1);
+		expect(cashLotServiceMock.allocateCashExpense).toHaveBeenCalledTimes(1);
+		expect(cashLotServiceMock.allocateCashExpense.mock.calls[0]?.[0]).toMatchObject({
+			id: expenseTransaction.id,
+			description: expenseTransaction.description,
+			currency: expenseTransaction.currency,
+		});
+	});
+
+	it('should restore cash lots when deleting a cash expense', async () => {
+		const cashExpense = createTransaction({
+			id: 303,
+			userId: 1,
+			description: 'Lunch',
+			amount: new Decimal(20000),
+			originalCurrencyAmount: new Decimal(20000),
+			currency: 'ARS',
+			type: 'debit',
+			categoryId: 31,
+			paymentMethodId: 41,
+		} as never);
+		const allocation = {
+			id: 1,
+			cashLotId: 8,
+			expenseTransactionId: cashExpense.id,
+			allocatedAmount: new Decimal(20000),
+			exchangeRate: new Decimal(1200),
+			sourceEquivalentAmount: 16.67,
+			createdAt: new Date('2026-04-02T12:00:00.000Z'),
+			cashLot: {
+				id: 8,
+				withdrawalDate: new Date('2026-04-01T10:00:00.000Z'),
+				sourceAmount: new Decimal(100),
+				sourceCurrency: 'USD',
+				destinationAmount: new Decimal(120000),
+				destinationCurrency: 'ARS',
+				exchangeRate: new Decimal(1200),
+				remainingAmount: new Decimal(100000),
+				migrationStatus: 'linked',
+				withdrawalTransaction: {
+					id: 201,
+					date: new Date('2026-04-01T10:00:00.000Z'),
+					description: 'ATM withdrawal',
+					amount: 100,
+					currency: 'USD',
+					category: { name: 'Other' },
+					paymentMethod: { name: 'Bank Account' },
+				},
+			},
+		};
+
+		prismaMock.transaction.findFirst
+			.mockResolvedValueOnce({
+				...cashExpense,
+				cashLot: null,
+				cashLotAllocations: [allocation],
+			} as never)
+			.mockResolvedValueOnce({
+				...cashExpense,
+				cashLot: null,
+				cashLotAllocations: [allocation],
+			} as never);
+		cashLotServiceMock.restoreExpenseAllocations.mockResolvedValue(1);
+		prismaMock.transaction.delete.mockResolvedValue({} as never);
+
+		const response = await request(app).delete('/api/transactions/303');
+
+		expect(response.status).toBe(204);
+		expect(cashLotServiceMock.restoreExpenseAllocations).toHaveBeenCalledTimes(1);
+		expect(cashLotServiceMock.restoreExpenseAllocations.mock.calls[0]?.[0]).toBe(303);
+		expect(cashLotServiceMock.restoreExpenseAllocations.mock.calls[0]?.[1]).toBe(1);
+		expect(cashLotServiceMock.restoreExpenseAllocations.mock.calls[0]?.[2]).toBeDefined();
+		expect(prismaMock.transaction.delete).toHaveBeenCalledWith({
+			where: { id: 303 },
+		});
+	});
+
+	it('should update a withdrawal cash lot when the withdrawal is edited', async () => {
+		const category = createCategory({ id: 32, userId: 1, name: 'Cash Withdrawal' } as never);
+		const paymentMethod = createPaymentMethod({ id: 42, userId: 1, name: 'Bank Account' } as never);
+		const withdrawalTransaction = createTransaction({
+			id: 304,
+			userId: 1,
+			description: 'ATM withdrawal',
+			amount: new Decimal(100),
+			originalCurrencyAmount: new Decimal(100),
+			currency: 'USD',
+			type: 'debit',
+			categoryId: category.id,
+			paymentMethodId: paymentMethod.id,
+		} as never);
+		const withdrawalLot = {
+			id: 9,
+			withdrawalTransactionId: withdrawalTransaction.id,
+			withdrawalDate: withdrawalTransaction.date,
+			sourceAmount: new Decimal(100),
+			sourceCurrency: 'USD',
+			destinationAmount: new Decimal(120000),
+			destinationCurrency: 'ARS',
+			exchangeRate: new Decimal(1200),
+			remainingAmount: new Decimal(120000),
+			migrationStatus: 'linked',
+			createdAt: new Date('2026-04-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+			allocations: [],
+			withdrawalTransaction: {
+				...withdrawalTransaction,
+				category,
+				paymentMethod,
+			},
+		};
+
+		prismaMock.transaction.findFirst
+			.mockResolvedValueOnce({
+				...withdrawalTransaction,
+				category,
+				paymentMethod,
+				cashLot: withdrawalLot,
+				cashLotAllocations: [],
+			} as never)
+			.mockResolvedValueOnce({
+				...withdrawalTransaction,
+				description: 'Edited withdrawal',
+				category,
+				paymentMethod,
+				cashLot: withdrawalLot,
+				cashLotAllocations: [],
+			} as never);
+		prismaMock.category.findFirst.mockResolvedValue(category);
+		prismaMock.paymentMethod.findFirst.mockResolvedValue(paymentMethod);
+		jest.spyOn(BaseTransactions, 'normalizeTransactionAmount').mockResolvedValue({
+			amount: new Decimal(100),
+			currency: 'USD',
+			originalCurrencyAmount: new Decimal(100),
+			exchangeRateUsed: new Decimal(1200),
+			exchangeRateSource: 'manual',
+			exchangeRateSourceKey: 'manual',
+		} as never);
+		prismaMock.transaction.update.mockResolvedValue({
+			...withdrawalTransaction,
+			description: 'Edited withdrawal',
+			category,
+			paymentMethod,
+		} as never);
+		cashLotServiceMock.updateWithdrawalCashLot.mockResolvedValue(withdrawalLot);
+
+		const response = await request(app).patch('/api/transactions/304').send({
+			date: '2026-04-01T00:00:00.000Z',
+			description: 'Edited withdrawal',
+			amount: 100,
+			category: 'Cash Withdrawal',
+			type: 'expense',
+			paymentMethodId: paymentMethod.id,
+			currency: 'USD',
+			isCashWithdrawal: true,
+			cashWithdrawalDestinationAmount: 120000,
+			cashWithdrawalDestinationCurrency: 'ARS',
+			cashWithdrawalExchangeRate: 1200,
+		});
+
+		expect(response.status).toBe(200);
+		expect(cashLotServiceMock.updateWithdrawalCashLot).toHaveBeenCalledTimes(1);
+		expect(cashLotServiceMock.updateWithdrawalCashLot.mock.calls[0]?.[0]).toMatchObject({
+			id: 304,
+			description: 'Edited withdrawal',
+		});
+		expect(cashLotServiceMock.updateWithdrawalCashLot.mock.calls[0]?.[1]).toEqual({
+			destinationAmount: 120000,
+			destinationCurrency: 'ARS',
+			exchangeRate: 1200,
+			migrationStatus: 'linked',
+		});
 	});
 });

--- a/tests/transaction-crud.test.ts
+++ b/tests/transaction-crud.test.ts
@@ -36,15 +36,7 @@ jest.mock('../modules/cash-lots/cash-lot.service', () => ({
 	},
 }));
 
-const cashLotServiceMock = CashLotServiceInstance as unknown as {
-	createWithdrawalCashLot: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-	updateWithdrawalCashLot: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-	allocateCashExpense: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-	restoreExpenseAllocations: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-	deleteWithdrawalCashLot: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-	getWithdrawalLotByTransactionId: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-	getExpenseAllocations: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
-};
+const cashLotServiceMock = jest.mocked(CashLotServiceInstance);
 
 describe('Transaction API (CRUD)', () => {
 	beforeEach(() => {
@@ -55,7 +47,8 @@ describe('Transaction API (CRUD)', () => {
 				throw new Error('Expected transaction callback');
 			}
 
-			return callback(prismaMock as never);
+			const transactionCallback = callback as (client: typeof prismaMock) => unknown;
+			return transactionCallback(prismaMock);
 		});
 	});
 
@@ -589,10 +582,11 @@ describe('Transaction API (CRUD)', () => {
 			paymentMethodId: paymentMethod.id,
 			categoryId: category.id,
 		} as never);
-		const withdrawalLot = {
-			id: 1,
-			withdrawalTransactionId: withdrawalTransaction.id,
-			withdrawalDate: withdrawalTransaction.date,
+			const withdrawalLot = {
+				id: 1,
+				userId: 1,
+				withdrawalTransactionId: withdrawalTransaction.id,
+				withdrawalDate: withdrawalTransaction.date,
 			sourceAmount: new Decimal(100),
 			sourceCurrency: 'USD',
 			destinationAmount: new Decimal(120000),
@@ -841,10 +835,11 @@ describe('Transaction API (CRUD)', () => {
 			categoryId: category.id,
 			paymentMethodId: paymentMethod.id,
 		} as never);
-		const withdrawalLot = {
-			id: 9,
-			withdrawalTransactionId: withdrawalTransaction.id,
-			withdrawalDate: withdrawalTransaction.date,
+			const withdrawalLot = {
+				id: 9,
+				userId: 1,
+				withdrawalTransactionId: withdrawalTransaction.id,
+				withdrawalDate: withdrawalTransaction.date,
 			sourceAmount: new Decimal(100),
 			sourceCurrency: 'USD',
 			destinationAmount: new Decimal(120000),


### PR DESCRIPTION
## Summary
- add CashLot and CashLotAllocation models
- create FIFO cash expense allocation and restore/delete handling
- wire cash withdrawal creation and cash expense allocation into transaction routes
- add docs and tests for the Cash Lots flow

## Validation
- backend targeted tests passed
- prisma generate passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cash lots: ATM withdrawals create expendable cash lots; cash expenses consume lots FIFO and show lot balance, rate, and linked withdrawal in transaction views
  * Transaction create/update/delete flows now handle cash withdrawals and automatic allocation/restoration of lots

* **Bug Fixes**
  * Budget totals, shared monthly summaries, and threshold notifications now exclude cash-lot withdrawals/allocations from spending aggregates

* **Documentation**
  * Added detailed cash lots docs covering behavior, examples, and edge cases

* **Tests**
  * Added unit and integration tests for cash-lot allocation and transaction flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->