### PR TITLE
fix(share): add monthly summary status endpoint

### DIFF
--- a/routes/router.ts
+++ b/routes/router.ts
@@ -2590,6 +2590,56 @@ router.post('/api/monthly-summaries/share', requireAuth, async (req: Request, re
 	}
 });
 
+router.get('/api/monthly-summaries/share/status', requireAuth, async (req: Request, res: Response) => {
+	try {
+		const month = Number(req.query.month);
+		const year = Number(req.query.year);
+
+		if (!isValidShareMonth(month, year)) {
+			return res.status(400).json({ message: 'month must be 1-12 and year must be valid' });
+		}
+
+		const share = await prisma.sharedMonthlySummary.findFirst({
+			where: {
+				userId: req.user.id,
+				month,
+				year,
+				revokedAt: null,
+			},
+			orderBy: {
+				createdAt: 'desc',
+			},
+		});
+
+		if (!share || (share.expiresAt && share.expiresAt.getTime() < Date.now())) {
+			return res.status(200).json({
+				shared: false,
+				month,
+				year,
+				token: null,
+				title: null,
+				createdAt: null,
+				expiresAt: null,
+				sharePath: null,
+			});
+		}
+
+		return res.status(200).json({
+			shared: true,
+			month: share.month,
+			year: share.year,
+			token: share.token,
+			title: share.title,
+			createdAt: share.createdAt.toISOString(),
+			expiresAt: share.expiresAt ? share.expiresAt.toISOString() : null,
+			sharePath: `/share/${share.token}`,
+		});
+	} catch (error) {
+		logger.error('Failed to fetch shared monthly summary status', { error, userId: req.user.id });
+		return res.status(500).json({ message: 'Failed to fetch shared monthly summary status' });
+	}
+});
+
 router.get('/api/public/monthly-summaries/:token', publicMonthlySummaryRateLimit, async (req: Request, res: Response) => {
 	try {
 		const token = String(req.params.token || '').trim();

--- a/tests/monthly-share-summary-status.test.ts
+++ b/tests/monthly-share-summary-status.test.ts
@@ -1,0 +1,83 @@
+import request from 'supertest';
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+
+jest.mock('../src/lib/auth.middleware', () => {
+	const mockRequireAuth = jest.fn((req: { user?: { id: number; email: string } }, _res: unknown, next: () => void) => {
+		req.user = { id: 1, email: 'test@example.com' };
+		next();
+	});
+
+	return {
+		requireAuth: mockRequireAuth,
+		requireRole: jest.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+	};
+});
+
+/* eslint-disable import/first */
+import app from '../app';
+import { prismaMock } from '../modules/database/database.module.mock';
+
+describe('Monthly share status API', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns the active shared summary status for a month', async () => {
+		prismaMock.sharedMonthlySummary.findFirst.mockResolvedValue({
+			id: 1,
+			userId: 1,
+			token: 'share-token',
+			month: 6,
+			year: 2026,
+			title: 'June summary',
+			revokedAt: null,
+			expiresAt: null,
+			createdAt: new Date('2026-06-10T12:00:00.000Z'),
+			updatedAt: new Date('2026-06-10T12:00:00.000Z'),
+		} as never);
+
+		const response = await request(app).get('/api/monthly-summaries/share/status?month=6&year=2026');
+
+		expect(response.status).toBe(200);
+		expect(response.body).toMatchObject({
+			shared: true,
+			month: 6,
+			year: 2026,
+			token: 'share-token',
+			title: 'June summary',
+			sharePath: '/share/share-token',
+		});
+		expect(prismaMock.sharedMonthlySummary.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					userId: 1,
+					month: 6,
+					year: 2026,
+					revokedAt: null,
+				},
+			})
+		);
+	});
+
+	it('returns an inactive status when the month has no active share', async () => {
+		prismaMock.sharedMonthlySummary.findFirst.mockResolvedValue(null);
+
+		const response = await request(app).get('/api/monthly-summaries/share/status?month=5&year=2026');
+
+		expect(response.status).toBe(200);
+		expect(response.body).toMatchObject({
+			shared: false,
+			month: 5,
+			year: 2026,
+			token: null,
+			sharePath: null,
+		});
+	});
+
+	it('rejects invalid month and year values', async () => {
+		const response = await request(app).get('/api/monthly-summaries/share/status?month=0&year=1999');
+
+		expect(response.status).toBe(400);
+		expect(response.body).toEqual({ message: 'month must be 1-12 and year must be valid' });
+	});
+});


### PR DESCRIPTION
Adds the authenticated monthly summary share-status endpoint and corresponding tests.