### PR TITLE
feat(budgets): add default reserve month-end allocation

### DIFF
--- a/controllers/categories.controller.ts
+++ b/controllers/categories.controller.ts
@@ -21,6 +21,7 @@ function mapCategoryBudgetFields(category: {
 	budgetType?: string | null;
 	targetAmount?: unknown;
 	currentAmount?: unknown;
+	isDefaultReserve?: boolean | null;
 	dueDay?: number | null;
 	targetDate?: Date | string | null;
 }) {
@@ -28,6 +29,7 @@ function mapCategoryBudgetFields(category: {
 		budgetType: normalizeBudgetType(category.budgetType),
 		targetAmount: category.targetAmount === null || category.targetAmount === undefined ? null : Number(category.targetAmount),
 		currentAmount: category.currentAmount === null || category.currentAmount === undefined ? null : Number(category.currentAmount),
+		isDefaultReserve: Boolean(category.isDefaultReserve),
 		dueDay: category.dueDay ?? null,
 		targetDate: category.targetDate ? new Date(category.targetDate).toISOString() : null,
 	};
@@ -82,7 +84,7 @@ export async function getCategories(req: Request, res: Response): Promise<void> 
  * Creates a new category and associates keywords.
  */
 export async function createCategory(req: Request, res: Response): Promise<void> {
-	const { name, description, icon, amountLimit, keywords, isCumulative, budgetType, targetAmount, currentAmount, dueDay, targetDate } = req.body as {
+	const { name, description, icon, amountLimit, keywords, isCumulative, budgetType, targetAmount, currentAmount, isDefaultReserve, dueDay, targetDate } = req.body as {
 		name: string;
 		description?: string;
 		icon?: string;
@@ -92,6 +94,7 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 		budgetType?: string;
 		targetAmount?: number | null;
 		currentAmount?: number | null;
+		isDefaultReserve?: boolean;
 		dueDay?: number | null;
 		targetDate?: string | null;
 	};
@@ -108,8 +111,22 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 		const normalizedCurrentAmount = normalizeOptionalAmount(currentAmount);
 		const normalizedDueDay = normalizeOptionalDueDay(dueDay);
 		const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
+		const normalizedIsDefaultReserve = !!isDefaultReserve && normalizedBudgetType === 'reserve';
 
 		const result = await prisma.$transaction(async (tx) => {
+			if (normalizedIsDefaultReserve) {
+				await tx.category.updateMany({
+					where: {
+						userId: req.user.id,
+						budgetType: 'reserve',
+						isDefaultReserve: true,
+					},
+					data: {
+						isDefaultReserve: false,
+					},
+				});
+			}
+
 			// 1. Create the category
 			const categoryCreateData = {
 					name,
@@ -119,6 +136,7 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 					budgetType: normalizedBudgetType,
 					targetAmount: normalizedTargetAmount === undefined ? null : normalizedTargetAmount,
 					currentAmount: normalizedCurrentAmount === undefined ? null : normalizedCurrentAmount,
+					isDefaultReserve: normalizedIsDefaultReserve,
 					dueDay: normalizedDueDay === undefined ? null : normalizedDueDay,
 					targetDate: normalizedTargetDate === undefined ? null : normalizedTargetDate,
 					isCumulative: !!isCumulative,
@@ -182,7 +200,7 @@ export async function createCategory(req: Request, res: Response): Promise<void>
  */
 export async function updateCategory(req: Request, res: Response): Promise<void> {
 	const id = Number(req.params.id);
-	const { name, description, icon, amountLimit, keywords, isCumulative, budgetType, targetAmount, currentAmount, currentCarryOver, dueDay, targetDate } = req.body as {
+	const { name, description, icon, amountLimit, keywords, isCumulative, budgetType, targetAmount, currentAmount, currentCarryOver, isDefaultReserve, dueDay, targetDate } = req.body as {
 		name?: string;
 		description?: string;
 		icon?: string;
@@ -193,6 +211,7 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 		targetAmount?: number | null;
 		currentAmount?: number | null;
 		currentCarryOver?: number | null;
+		isDefaultReserve?: boolean;
 		dueDay?: number | null;
 		targetDate?: string | null;
 	};
@@ -232,6 +251,21 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 			const normalizedCurrentAmount = normalizeOptionalAmount(currentAmount);
 			const normalizedDueDay = normalizeOptionalDueDay(dueDay);
 			const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
+			const normalizedBudgetType = budgetType !== undefined ? normalizeBudgetType(budgetType) : existing.budgetType;
+			const normalizedIsDefaultReserve = !!isDefaultReserve && normalizedBudgetType === 'reserve';
+
+			if (normalizedIsDefaultReserve) {
+				await tx.category.updateMany({
+					where: {
+						userId: req.user.id,
+						budgetType: 'reserve',
+						isDefaultReserve: true,
+					},
+					data: {
+						isDefaultReserve: false,
+					},
+				});
+			}
 
 			// 1. Update category fields
 			const categoryUpdateData = {
@@ -239,9 +273,10 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 						description: description !== undefined ? description : existing.description,
 						icon: icon !== undefined ? icon : (existing as unknown as CategoryWithOptionalIcon).icon,
 						amountLimit: amountLimit !== undefined ? amountLimit : existing.amountLimit,
-						budgetType: budgetType !== undefined ? normalizeBudgetType(budgetType) : existing.budgetType,
+						budgetType: normalizedBudgetType,
 						targetAmount: normalizedTargetAmount !== undefined ? normalizedTargetAmount : existing.targetAmount,
 						currentAmount: normalizedCurrentAmount !== undefined ? normalizedCurrentAmount : existing.currentAmount,
+						isDefaultReserve: normalizedBudgetType === 'reserve' ? normalizedIsDefaultReserve : false,
 						dueDay: normalizedDueDay !== undefined ? normalizedDueDay : existing.dueDay,
 						targetDate: normalizedTargetDate !== undefined ? normalizedTargetDate : existing.targetDate,
 						isCumulative: isCumulative !== undefined ? isCumulative : existing.isCumulative,

--- a/controllers/categories.controller.ts
+++ b/controllers/categories.controller.ts
@@ -111,7 +111,10 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 		const normalizedCurrentAmount = normalizeOptionalAmount(currentAmount);
 		const normalizedDueDay = normalizeOptionalDueDay(dueDay);
 		const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
-		const normalizedIsDefaultReserve = !!isDefaultReserve && normalizedBudgetType === 'reserve';
+		if (isDefaultReserve !== undefined && typeof isDefaultReserve !== 'boolean') {
+			throw new Error('Invalid default reserve value');
+		}
+		const normalizedIsDefaultReserve = isDefaultReserve === true && normalizedBudgetType === 'reserve';
 
 		const result = await prisma.$transaction(async (tx) => {
 			if (normalizedIsDefaultReserve) {
@@ -190,6 +193,10 @@ export async function createCategory(req: Request, res: Response): Promise<void>
 			res.status(400).json({ message: 'A category with this name already exists' });
 			return;
 		}
+		if (error instanceof Error && error.message === 'Invalid default reserve value') {
+			res.status(400).json({ message: error.message });
+			return;
+		}
 		logger.error('Failed to create category', { userId: req.user.id, error });
 		res.status(500).json({ message: 'Failed to create category' });
 	}
@@ -252,7 +259,12 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 			const normalizedDueDay = normalizeOptionalDueDay(dueDay);
 			const normalizedTargetDate = normalizeOptionalTargetDate(targetDate);
 			const normalizedBudgetType = budgetType !== undefined ? normalizeBudgetType(budgetType) : existing.budgetType;
-			const normalizedIsDefaultReserve = !!isDefaultReserve && normalizedBudgetType === 'reserve';
+			if (isDefaultReserve !== undefined && typeof isDefaultReserve !== 'boolean') {
+				throw new Error('Invalid default reserve value');
+			}
+			const normalizedIsDefaultReserve = isDefaultReserve !== undefined
+				? isDefaultReserve && normalizedBudgetType === 'reserve'
+				: (normalizedBudgetType === 'reserve' ? Boolean(existing.isDefaultReserve) : false);
 
 			if (normalizedIsDefaultReserve) {
 				await tx.category.updateMany({
@@ -363,6 +375,10 @@ export async function updateCategory(req: Request, res: Response): Promise<void>
 		}
 		if (error instanceof Error && error.message === 'Budget period not found') {
 			res.status(404).json({ message: error.message });
+			return;
+		}
+		if (error instanceof Error && error.message === 'Invalid default reserve value') {
+			res.status(400).json({ message: error.message });
 			return;
 		}
 		logger.error('Failed to update category', { userId: req.user.id, id, error });

--- a/modules/ai-assistant/receipt-ocr-job-processor.service.test.ts
+++ b/modules/ai-assistant/receipt-ocr-job-processor.service.test.ts
@@ -315,7 +315,7 @@ describe('receipt-ocr-job-processor.service', () => {
 				description: null,
 				amount: 15,
 				currency: 'USD',
-				type: 'credit',
+				type: 'income',
 				referenceId: null,
 				category: null,
 			},

--- a/modules/budgets/default-reserve.service.test.ts
+++ b/modules/budgets/default-reserve.service.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Decimal } from '@prisma/client/runtime/library';
+import { DefaultReserve } from './default-reserve.service';
+import { prismaMock } from '../database/database.module.mock';
+
+describe('DefaultReserveService', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should apply monthly surplus to the default reserve once per month', async () => {
+		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
+		const categoryMock = prismaMock.category as any;
+		const transactionMock = prismaMock.transaction as any;
+		const allocationFindUniqueMock = jest.fn() as any;
+		allocationFindUniqueMock.mockResolvedValue(null);
+		const allocationCreateMock = jest.fn() as any;
+		allocationCreateMock.mockResolvedValue({
+			id: 1,
+			userId: 2,
+			categoryId: 88,
+			month: 5,
+			year: 2026,
+			amount: new Decimal(240),
+		});
+		const categoryUpdateMock = jest.fn() as any;
+		categoryUpdateMock.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			currentAmount: new Decimal(340),
+		});
+		const transactionClientMock = {
+			monthlyReserveAllocation: {
+				findUnique: allocationFindUniqueMock,
+				create: allocationCreateMock,
+			},
+			category: {
+				update: categoryUpdateMock,
+			},
+		};
+
+		reserveAllocationMock.findUnique.mockResolvedValue(null);
+		categoryMock.findFirst.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			name: 'Emergency reserve',
+			currentAmount: new Decimal(100),
+		});
+		transactionMock.findMany.mockResolvedValue([
+			{ type: 'income', amount: new Decimal(1000), referenceId: null },
+			{ type: 'expense', amount: new Decimal(760), referenceId: null },
+		]);
+
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback(transactionClientMock as any);
+			})
+		);
+
+		const result = await DefaultReserve.applyMonthlySurplusToDefaultReserve(2, 88, 5, 2026);
+
+		expect(result).toMatchObject({
+			id: 1,
+			userId: 2,
+			categoryId: 88,
+			month: 5,
+			year: 2026,
+		});
+		expect(prismaMock.category.findFirst).toHaveBeenCalledWith({
+			where: {
+				id: 88,
+				userId: 2,
+				budgetType: 'reserve',
+				isDefaultReserve: true,
+			},
+			select: {
+				id: true,
+				name: true,
+				currentAmount: true,
+			},
+		});
+		expect(prismaMock.$transaction).toHaveBeenCalled();
+	});
+
+	it('should skip allocation when there is no surplus', async () => {
+		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
+		const categoryMock = prismaMock.category as any;
+		const transactionMock = prismaMock.transaction as any;
+
+		reserveAllocationMock.findUnique.mockResolvedValue(null);
+		categoryMock.findFirst.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			name: 'Emergency reserve',
+			currentAmount: new Decimal(100),
+		});
+		transactionMock.findMany.mockResolvedValue([
+			{ type: 'expense', amount: new Decimal(760), referenceId: null },
+		]);
+
+		const result = await DefaultReserve.applyMonthlySurplusToDefaultReserve(2, 88, 5, 2026);
+
+		expect(result).toBeNull();
+		expect(prismaMock.$transaction).not.toHaveBeenCalled();
+	});
+});

--- a/modules/budgets/default-reserve.service.test.ts
+++ b/modules/budgets/default-reserve.service.test.ts
@@ -351,8 +351,9 @@ describe('DefaultReserveService', () => {
 		expect(categoryUpdateMock).toHaveBeenCalledWith({
 			where: { id: 88 },
 			data: {
-				currentAmount: 220,
+				currentAmount: expect.anything(),
 			},
 		});
+		expect(categoryUpdateMock.mock.calls[0][0].data.currentAmount.toString()).toBe('220');
 	});
 });

--- a/modules/budgets/default-reserve.service.test.ts
+++ b/modules/budgets/default-reserve.service.test.ts
@@ -8,6 +8,88 @@ describe('DefaultReserveService', () => {
 		jest.clearAllMocks();
 	});
 
+	it('should sync all default reserve categories for the prior month', async () => {
+		const categoryMock = prismaMock.category as any;
+		const allocationFindUniqueMock = jest.fn() as any;
+		const allocationCreateMock = jest.fn() as any;
+		const categoryUpdateMock = jest.fn() as any;
+		const transactionMock = prismaMock.transaction as any;
+
+		categoryMock.findMany.mockResolvedValue([
+			{ id: 88, userId: 2, name: 'Emergency reserve' },
+			{ id: 90, userId: 3, name: 'Backup reserve' },
+		]);
+		categoryMock.findFirst.mockImplementation(async ({ where }: { where: { id: number; userId: number } }) => {
+			if (where.id === 88 && where.userId === 2) {
+				return {
+					id: 88,
+					userId: 2,
+					name: 'Emergency reserve',
+					currentAmount: new Decimal(100),
+				};
+			}
+
+			return null;
+		});
+
+		allocationFindUniqueMock.mockResolvedValue(null);
+		allocationCreateMock.mockResolvedValue({
+			id: 1,
+			userId: 2,
+			categoryId: 88,
+			month: 5,
+			year: 2026,
+			amount: new Decimal(240),
+		});
+		categoryUpdateMock.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			currentAmount: new Decimal(340),
+		});
+
+		transactionMock.findMany.mockResolvedValue([
+			{ type: 'income', amount: new Decimal(1000), referenceId: null },
+			{ type: 'expense', amount: new Decimal(760), referenceId: null },
+		]);
+
+		const transactionClientMock = {
+			monthlyReserveAllocation: {
+				findUnique: allocationFindUniqueMock,
+				create: allocationCreateMock,
+			},
+			category: {
+				update: categoryUpdateMock,
+			},
+		};
+
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback(transactionClientMock as any);
+			})
+		);
+
+		const result = await DefaultReserve.syncDefaultReserveAllocations(new Date('2026-06-15T12:00:00.000Z'));
+
+		expect(result).toHaveLength(1);
+		expect(categoryMock.findMany).toHaveBeenCalledWith({
+			where: {
+				budgetType: 'reserve',
+				isDefaultReserve: true,
+			},
+			select: {
+				id: true,
+				userId: true,
+				name: true,
+			},
+		});
+		expect(prismaMock.$transaction).toHaveBeenCalled();
+	});
+
 	it('should apply monthly surplus to the default reserve once per month', async () => {
 		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
 		const categoryMock = prismaMock.category as any;
@@ -87,6 +169,102 @@ describe('DefaultReserveService', () => {
 		expect(prismaMock.$transaction).toHaveBeenCalled();
 	});
 
+	it('should return the existing allocation when the month has already been synced', async () => {
+		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
+		const categoryMock = prismaMock.category as any;
+		const transactionMock = prismaMock.transaction as any;
+		const existingAllocation = {
+			id: 9,
+			userId: 2,
+			categoryId: 88,
+			month: 5,
+			year: 2026,
+			amount: new Decimal(240),
+		};
+
+		reserveAllocationMock.findUnique.mockResolvedValue(existingAllocation);
+		categoryMock.findFirst.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			name: 'Emergency reserve',
+			currentAmount: new Decimal(100),
+		});
+		transactionMock.findMany.mockResolvedValue([
+			{ type: 'income', amount: new Decimal(1000), referenceId: null },
+			{ type: 'expense', amount: new Decimal(760), referenceId: null },
+		]);
+
+		const result = await DefaultReserve.applyMonthlySurplusToDefaultReserve(2, 88, 5, 2026);
+
+		expect(result).toEqual(existingAllocation);
+		expect(prismaMock.$transaction).not.toHaveBeenCalled();
+		expect(prismaMock.category.findFirst).not.toHaveBeenCalled();
+	});
+
+	it('should skip allocation when the reserve category no longer exists', async () => {
+		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
+		const categoryMock = prismaMock.category as any;
+
+		reserveAllocationMock.findUnique.mockResolvedValue(null);
+		categoryMock.findFirst.mockResolvedValue(null);
+
+		const result = await DefaultReserve.applyMonthlySurplusToDefaultReserve(2, 88, 5, 2026);
+
+		expect(result).toBeNull();
+		expect(prismaMock.$transaction).not.toHaveBeenCalled();
+	});
+
+	it('should keep the concurrent allocation from the transaction lock path', async () => {
+		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
+		const categoryMock = prismaMock.category as any;
+		const transactionMock = prismaMock.transaction as any;
+		const concurrentAllocation = {
+			id: 12,
+			userId: 2,
+			categoryId: 88,
+			month: 5,
+			year: 2026,
+			amount: new Decimal(240),
+		};
+		const concurrentFindUniqueMock: any = jest.fn();
+		concurrentFindUniqueMock.mockResolvedValue(concurrentAllocation);
+
+		reserveAllocationMock.findUnique.mockResolvedValue(null);
+		categoryMock.findFirst.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			name: 'Emergency reserve',
+			currentAmount: new Decimal(100),
+		});
+		transactionMock.findMany.mockResolvedValue([
+			{ type: 'income', amount: new Decimal(1000), referenceId: null },
+			{ type: 'expense', amount: new Decimal(760), referenceId: null },
+		]);
+
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+					return callback({
+						monthlyReserveAllocation: {
+							findUnique: concurrentFindUniqueMock,
+							create: jest.fn(),
+						},
+						category: {
+						update: jest.fn(),
+					},
+				} as any);
+			})
+		);
+
+		const result = await DefaultReserve.applyMonthlySurplusToDefaultReserve(2, 88, 5, 2026);
+
+		expect(result).toEqual(concurrentAllocation);
+	});
+
 	it('should skip allocation when there is no surplus', async () => {
 		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
 		const categoryMock = prismaMock.category as any;
@@ -107,5 +285,74 @@ describe('DefaultReserveService', () => {
 
 		expect(result).toBeNull();
 		expect(prismaMock.$transaction).not.toHaveBeenCalled();
+	});
+
+	it('should ignore overflow transfer rows when calculating surplus', async () => {
+		const reserveAllocationMock = prismaMock.monthlyReserveAllocation as any;
+		const categoryMock = prismaMock.category as any;
+		const transactionMock = prismaMock.transaction as any;
+		const allocationCreateMock = jest.fn() as any;
+		const categoryUpdateMock = jest.fn() as any;
+		const ignoreTransferFindUniqueMock: any = jest.fn();
+		ignoreTransferFindUniqueMock.mockResolvedValue(null);
+		const transactionClientMock = {
+			monthlyReserveAllocation: {
+				findUnique: ignoreTransferFindUniqueMock,
+				create: allocationCreateMock.mockResolvedValue({
+					id: 7,
+					userId: 2,
+					categoryId: 88,
+					month: 5,
+					year: 2026,
+					amount: new Decimal(120),
+				}),
+			},
+			category: {
+				update: categoryUpdateMock.mockResolvedValue({
+					id: 88,
+					userId: 2,
+					currentAmount: new Decimal(220),
+				}),
+			},
+		};
+
+		reserveAllocationMock.findUnique.mockResolvedValue(null);
+		categoryMock.findFirst.mockResolvedValue({
+			id: 88,
+			userId: 2,
+			name: 'Emergency reserve',
+			currentAmount: new Decimal(100),
+		});
+		transactionMock.findMany.mockResolvedValue([
+			{ type: 'income', amount: new Decimal(150), referenceId: null },
+			{ type: 'expense', amount: new Decimal(10), referenceId: 'bo:transfer-1' },
+			{ type: 'expense', amount: new Decimal(30), referenceId: null },
+		]);
+
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback(transactionClientMock as any);
+			})
+		);
+
+		const result = await DefaultReserve.applyMonthlySurplusToDefaultReserve(2, 88, 5, 2026);
+
+		expect(result).toMatchObject({
+			id: 7,
+			userId: 2,
+			categoryId: 88,
+			amount: new Decimal(120),
+		});
+		expect(categoryUpdateMock).toHaveBeenCalledWith({
+			where: { id: 88 },
+			data: {
+				currentAmount: 220,
+			},
+		});
 	});
 });

--- a/modules/budgets/default-reserve.service.ts
+++ b/modules/budgets/default-reserve.service.ts
@@ -1,0 +1,186 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaModule as prisma } from '../database/database.module';
+import logger from '../../src/lib/logger';
+import { isBudgetOverflowTransferTransaction } from '../../src/lib/budget-overflow-transfers';
+
+type MonthlyReserveAllocationRecord = {
+	id: number;
+	userId: number;
+	categoryId: number;
+	month: number;
+	year: number;
+	amount: Prisma.Decimal;
+};
+
+export class DefaultReserveService {
+	private _db: PrismaClient;
+
+	constructor() {
+		this._db = prisma;
+	}
+
+	async syncDefaultReserveAllocations(referenceDate: Date = new Date()) {
+		const previousMonthDate = new Date(Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), 1));
+		previousMonthDate.setUTCMonth(previousMonthDate.getUTCMonth() - 1);
+		const month = previousMonthDate.getUTCMonth() + 1;
+		const year = previousMonthDate.getUTCFullYear();
+
+		const defaultReserveCategories = await this._db.category.findMany({
+			where: {
+				budgetType: 'reserve',
+				isDefaultReserve: true,
+			},
+			select: {
+				id: true,
+				userId: true,
+				name: true,
+			},
+		});
+
+		const allocations: MonthlyReserveAllocationRecord[] = [];
+
+		for (const category of defaultReserveCategories) {
+			const allocation = await this.applyMonthlySurplusToDefaultReserve(category.userId, category.id, month, year);
+			if (allocation) {
+				allocations.push(allocation);
+			}
+		}
+
+		return allocations;
+	}
+
+	async applyMonthlySurplusToDefaultReserve(
+		userId: number,
+		categoryId: number,
+		month: number,
+		year: number
+	): Promise<MonthlyReserveAllocationRecord | null> {
+		const existingAllocation = await this._db.monthlyReserveAllocation.findUnique({
+			where: {
+				userId_month_year: {
+					userId,
+					month,
+					year,
+				},
+			},
+		});
+
+		if (existingAllocation) {
+			return existingAllocation;
+		}
+
+		const category = await this._db.category.findFirst({
+			where: {
+				id: categoryId,
+				userId,
+				budgetType: 'reserve',
+				isDefaultReserve: true,
+			},
+			select: {
+				id: true,
+				name: true,
+				currentAmount: true,
+			},
+		});
+
+		if (!category) {
+			return null;
+		}
+
+		const { surplus, transactionCount } = await this.calculateMonthlySurplus(userId, month, year);
+		if (surplus <= 0) {
+			logger.info('Default reserve sync skipped because there is no surplus to allocate', {
+				userId,
+				categoryId,
+				month,
+				year,
+				transactionCount,
+			});
+			return null;
+		}
+
+		return await this._db.$transaction(async (tx) => {
+			const concurrentAllocation = await tx.monthlyReserveAllocation.findUnique({
+				where: {
+					userId_month_year: {
+						userId,
+						month,
+						year,
+					},
+				},
+			});
+
+			if (concurrentAllocation) {
+				return concurrentAllocation;
+			}
+
+			await tx.category.update({
+				where: { id: category.id },
+				data: {
+					currentAmount: Number(category.currentAmount ?? 0) + surplus,
+				},
+			});
+
+			const allocation = await tx.monthlyReserveAllocation.create({
+				data: {
+					userId,
+					categoryId: category.id,
+					month,
+					year,
+					amount: surplus,
+				},
+			});
+
+			logger.info('Applied default reserve monthly surplus', {
+				userId,
+				categoryId: category.id,
+				month,
+				year,
+				surplus,
+				categoryName: category.name,
+			});
+
+			return allocation;
+		});
+	}
+
+	private async calculateMonthlySurplus(userId: number, month: number, year: number) {
+		const monthStart = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
+		const monthEnd = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+
+		const transactions = await this._db.transaction.findMany({
+			where: {
+				userId,
+				date: {
+					gte: monthStart,
+					lt: monthEnd,
+				},
+				cashLot: {
+					is: null,
+				},
+			},
+			select: {
+				type: true,
+				amount: true,
+				referenceId: true,
+			},
+		});
+
+		const visibleTransactions = transactions.filter((transaction) => !isBudgetOverflowTransferTransaction(transaction.referenceId));
+
+		const income = visibleTransactions
+			.filter((transaction) => transaction.type === 'income')
+			.reduce((sum, transaction) => sum + Number(transaction.amount ?? 0), 0);
+
+		const expenses = visibleTransactions
+			.filter((transaction) => transaction.type === 'expense')
+			.reduce((sum, transaction) => sum + Number(transaction.amount ?? 0), 0);
+
+		return {
+			surplus: Math.max(0, Math.round((income - expenses) * 100) / 100),
+			transactionCount: visibleTransactions.length,
+		};
+	}
+}
+
+export const DefaultReserve = new DefaultReserveService();

--- a/modules/budgets/default-reserve.service.ts
+++ b/modules/budgets/default-reserve.service.ts
@@ -114,10 +114,11 @@ export class DefaultReserveService {
 				return concurrentAllocation;
 			}
 
+			const currentAmount = new Prisma.Decimal(category.currentAmount ?? 0);
 			await tx.category.update({
 				where: { id: category.id },
 				data: {
-					currentAmount: Number(category.currentAmount ?? 0) + surplus,
+					currentAmount: currentAmount.add(surplus),
 				},
 			});
 

--- a/modules/crons/task-queue.cron.ts
+++ b/modules/crons/task-queue.cron.ts
@@ -17,6 +17,7 @@ import { cleanupOldReceiptProcessingImages } from '../../src/lib/receipt-image-s
 import { ReceiptOcrQueueService } from '../ai-assistant/receipt-ocr-queue.service';
 import { processReceiptOcrJob } from '../ai-assistant/receipt-ocr-job-processor.service';
 import { fetchAndStoreArsUsdRateByDate } from '../../src/helpers/rate.helper';
+import { DefaultReserve } from '../budgets/default-reserve.service';
 
 const CRON_EXPRESSIONS = {
 	createDailyTask: process.env.CRON_CREATE_DAILY_TASK || '0 10,16 * * 1-5',
@@ -26,6 +27,7 @@ const CRON_EXPRESSIONS = {
 	cleanupReceiptProcessingImages: process.env.CRON_CLEAN_RECEIPT_PROCESSING_IMAGES || '0 * * * *',
 	processReceiptOcrQueue: process.env.CRON_PROCESS_RECEIPT_OCR_QUEUE || '*/10 * * * * *',
 	syncArsUsdRate: process.env.CRON_SYNC_ARS_USD_RATE || '0 0,12 * * *',
+	syncDefaultReserve: process.env.CRON_SYNC_DEFAULT_RESERVE || '15 0 * * *',
 };
 
 export class TaskQueueModule {
@@ -70,6 +72,11 @@ export class TaskQueueModule {
 		scheduled: true,
 	});
 
+	private syncDefaultReserve = cron.schedule(CRON_EXPRESSIONS.syncDefaultReserve, this._syncDefaultReserve.bind(this), {
+		timezone: config.CRON_TIMEZONE,
+		scheduled: true,
+	});
+
 	private isProcessingReceiptQueue = false;
 
 	private async withCronLock<T>(lockName: string, ttlSeconds: number, fn: () => Promise<T>): Promise<T | null> {
@@ -102,6 +109,7 @@ export class TaskQueueModule {
 		this.cleanupReceiptProcessingImages.start();
 		this.processReceiptOcrQueue.start();
 		this.syncArsUsdRate.start();
+		this.syncDefaultReserve.start();
 	}
 
 	private async _createDailyExchangeRateTask() {
@@ -223,6 +231,18 @@ export class TaskQueueModule {
 					error,
 					house: config.ARS_USD_EXCHANGE_HOUSE,
 				});
+			}
+		});
+	}
+
+	private async _syncDefaultReserve() {
+		await this.withCronLock('syncDefaultReserve', 900, async () => {
+			try {
+				logger.info('Running cron job to sync default reserve allocations...');
+				const allocations = await DefaultReserve.syncDefaultReserveAllocations(new Date());
+				logger.info('Default reserve sync completed', { count: allocations.length });
+			} catch (error) {
+				logger.error('Error syncing default reserve allocations', { error });
 			}
 		});
 	}

--- a/modules/mercantil-panama/mercantil-panama.module.test.ts
+++ b/modules/mercantil-panama/mercantil-panama.module.test.ts
@@ -37,8 +37,8 @@ describe('Mercantil Panamá Module: ', () => {
 		expect(spyCategoryFindMany).toHaveBeenCalledTimes(1);
 
 		expect(data).toHaveLength(3);
-		expect((data[0] as { type: string }).type).toBe('credit');
-		expect((data[1] as { type: string }).type).toBe('debit');
+		expect((data[0] as { type: string }).type).toBe('income');
+		expect((data[1] as { type: string }).type).toBe('expense');
 	});
 	test('Register 0 transactions', async () => {
 		prisma.transaction.create = sandbox.stub().callsFake(async ({ data }: { data: { type: string } }) => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zentra-api",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zentra-api",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"dependencies": {
 				"@babel/core": "7.24.3",
 				"@babel/node": "7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zentra-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "start:dev": "ts-node ./bin/www.ts",
     "start": "node ./dist/bin/www.js",

--- a/prisma/migrations/20260615140000_add_default_reserve_flag/migration.sql
+++ b/prisma/migrations/20260615140000_add_default_reserve_flag/migration.sql
@@ -1,0 +1,3 @@
+-- Add a default reserve marker to categories
+ALTER TABLE `Category`
+ADD COLUMN `isDefaultReserve` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20260615143000_add_monthly_reserve_allocations/migration.sql
+++ b/prisma/migrations/20260615143000_add_monthly_reserve_allocations/migration.sql
@@ -1,0 +1,24 @@
+-- Track monthly surplus allocations into the default reserve
+CREATE TABLE `MonthlyReserveAllocation` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `userId` INT NOT NULL,
+  `categoryId` INT NOT NULL,
+  `month` INT NOT NULL,
+  `year` INT NOT NULL,
+  `amount` DECIMAL(10,2) NOT NULL,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE UNIQUE INDEX `MonthlyReserveAllocation_userId_month_year_key` ON `MonthlyReserveAllocation`(`userId`, `month`, `year`);
+CREATE INDEX `MonthlyReserveAllocation_categoryId_fkey` ON `MonthlyReserveAllocation`(`categoryId`);
+CREATE INDEX `MonthlyReserveAllocation_userId_fkey` ON `MonthlyReserveAllocation`(`userId`);
+
+ALTER TABLE `MonthlyReserveAllocation`
+  ADD CONSTRAINT `MonthlyReserveAllocation_userId_fkey`
+  FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `MonthlyReserveAllocation`
+  ADD CONSTRAINT `MonthlyReserveAllocation_categoryId_fkey`
+  FOREIGN KEY (`categoryId`) REFERENCES `Category`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   shops                   Shop[]
   suscriptions            Suscription[]
   sharedMonthlySummaries  SharedMonthlySummary[]
+  monthlyReserveAllocations MonthlyReserveAllocation[]
   transactions            Transaction[]
 }
 
@@ -44,6 +45,7 @@ model Category {
   budgetType       String            @default("spending") @db.VarChar(20)
   targetAmount     Decimal?          @db.Decimal(10, 2)
   currentAmount    Decimal?          @db.Decimal(10, 2)
+  isDefaultReserve Boolean           @default(false)
   dueDay           Int?
   targetDate       DateTime?
   isCumulative     Boolean           @default(false)
@@ -58,6 +60,7 @@ model Category {
   targetFallbackRules BudgetFallbackRule[] @relation("BudgetFallbackTarget")
   sourceOverflowAssignments BudgetOverflowAssignment[] @relation("BudgetOverflowSource")
   targetOverflowAssignments BudgetOverflowAssignment[] @relation("BudgetOverflowTarget")
+  monthlyReserveAllocations MonthlyReserveAllocation[]
 
   @@unique([name, userId])
   @@index([userId], map: "Category_userId_fkey")
@@ -108,6 +111,23 @@ model BudgetPeriod {
 
   @@unique([categoryId, year, month])
   @@index([categoryId], map: "BudgetPeriod_categoryId_fkey")
+}
+
+model MonthlyReserveAllocation {
+  id         Int      @id @default(autoincrement())
+  userId     Int
+  categoryId Int
+  month      Int
+  year       Int
+  amount     Decimal  @db.Decimal(10, 2)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  category   Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, month, year])
+  @@index([categoryId], map: "MonthlyReserveAllocation_categoryId_fkey")
+  @@index([userId], map: "MonthlyReserveAllocation_userId_fkey")
 }
 
 model Keyword {

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -364,6 +364,10 @@ function calculateBudgetOverflowState(
 	};
 }
 
+function roundAmount(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
 async function loadMonthlyBudgetOverflowStates(
 	db: Prisma.TransactionClient | typeof prisma,
 	userId: number,
@@ -2153,6 +2157,96 @@ router.get('/api/budgets', requireAuth, async (req: Request, res: Response) => {
 		res.status(200).json(budgets);
 	} catch (error) {
 		res.status(500).json({ message: 'Failed to fetch budgets' });
+	}
+});
+
+router.get('/api/budgets/monthly-overview', requireAuth, async (req: Request, res: Response) => {
+	try {
+		const month = Number(req.query.month);
+		const year = Number(req.query.year);
+
+		if (!Number.isInteger(month) || month < 1 || month > 12 || !Number.isInteger(year) || year < 2000 || year > 2100) {
+			return res.status(400).json({ message: 'month and year are required' });
+		}
+
+		const categories = await prisma.category.findMany({
+			where: {
+				userId: req.user.id,
+				amountLimit: {
+					gt: 0,
+				},
+			},
+			select: {
+				id: true,
+				name: true,
+				amountLimit: true,
+			},
+			orderBy: {
+				name: 'asc',
+			},
+		});
+
+		const overflowStateByCategoryId = await loadMonthlyBudgetOverflowStates(
+			prisma,
+			req.user.id,
+			month,
+			year
+		);
+
+		const budgets = categories
+			.map((category) => {
+				const state = overflowStateByCategoryId.get(category.id);
+				if (!state) {
+					return null;
+				}
+
+				const overage = roundAmount(Math.max(state.rawSpent - state.limit, 0));
+				const adjustedRemaining = roundAmount(state.effectiveBudget - state.adjustedSpent);
+				const percentage = roundAmount(state.effectiveBudget > 0 ? (state.adjustedSpent / state.effectiveBudget) * 100 : 0);
+
+				return {
+					categoryId: category.id,
+					category: category.name,
+					limit: roundAmount(Number(state.limit)),
+					carryOver: roundAmount(Number(state.carryOver)),
+					effectiveBudget: roundAmount(Number(state.effectiveBudget)),
+					rawSpent: roundAmount(Number(state.rawSpent)),
+					adjustedSpent: roundAmount(Number(state.adjustedSpent)),
+					remaining: adjustedRemaining,
+					percentage,
+					overage,
+					status:
+						state.effectiveBudget === 0
+							? 'none'
+							: overage > 0
+								? 'over'
+								: percentage > 80
+									? 'warning'
+									: 'good',
+				};
+			})
+			.filter((budget): budget is NonNullable<typeof budget> => budget !== null)
+			.sort((left, right) => right.rawSpent - left.rawSpent);
+
+		const totals = budgets.reduce(
+			(accumulator, budget) => {
+				accumulator.totalBudget += budget.effectiveBudget;
+				accumulator.totalCarryOver += budget.carryOver;
+				accumulator.remainingBudget += budget.remaining;
+				return accumulator;
+			},
+			{ totalBudget: 0, totalCarryOver: 0, remainingBudget: 0 }
+		);
+
+		return res.status(200).json({
+			month,
+			year,
+			budgets,
+			totals,
+		});
+	} catch (error) {
+		logger.error('Failed to fetch monthly budget overview', { error, userId: req.user.id });
+		return res.status(500).json({ message: 'Failed to fetch monthly budget overview' });
 	}
 });
 

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -2150,6 +2150,7 @@ router.get('/api/budgets', requireAuth, async (req: Request, res: Response) => {
 				type: category.budgetType || 'spending',
 				targetAmount: category.targetAmount === null ? null : Number(category.targetAmount),
 				currentAmount: category.currentAmount === null ? null : Number(category.currentAmount),
+				isDefaultReserve: Boolean(category.isDefaultReserve),
 				dueDay: category.dueDay ?? null,
 				targetDate: category.targetDate ? category.targetDate.toISOString() : null,
 			}));
@@ -2253,11 +2254,12 @@ router.get('/api/budgets/monthly-overview', requireAuth, async (req: Request, re
 router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) => {
 	try {
 		const id = Number(req.params.id);
-		const { limit, type, targetAmount, currentAmount, dueDay, targetDate } = req.body as {
+		const { limit, type, targetAmount, currentAmount, isDefaultReserve, dueDay, targetDate } = req.body as {
 			limit?: number;
 			type?: 'spending' | 'recurring' | 'goal' | 'reserve';
 			targetAmount?: number | null;
 			currentAmount?: number | null;
+			isDefaultReserve?: boolean;
 			dueDay?: number | null;
 			targetDate?: string | null;
 		};
@@ -2274,10 +2276,13 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 			return res.status(404).json({ message: 'Category not found' });
 		}
 
-		const updateData: Prisma.CategoryUpdateInput = { amountLimit: limit };
-		if (type !== undefined) {
-			updateData.budgetType = normalizeBudgetType(type);
-		}
+		const normalizedBudgetType = type !== undefined ? normalizeBudgetType(type) : (category.budgetType || 'spending');
+		const normalizedIsDefaultReserve = !!isDefaultReserve && normalizedBudgetType === 'reserve';
+		const updateData: Prisma.CategoryUpdateInput = {
+			amountLimit: limit,
+			budgetType: normalizedBudgetType,
+			isDefaultReserve: normalizedIsDefaultReserve,
+		};
 		const normalizedTargetAmount = normalizeOptionalAmount(targetAmount);
 		if (normalizedTargetAmount !== undefined) {
 			updateData.targetAmount = normalizedTargetAmount;
@@ -2295,9 +2300,24 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 			updateData.targetDate = normalizedTargetDate;
 		}
 
-		const updated = await prisma.category.update({
-			where: { id: category.id },
-			data: updateData,
+		const updated = await prisma.$transaction(async (tx) => {
+			if (normalizedIsDefaultReserve) {
+				await tx.category.updateMany({
+					where: {
+						userId: req.user.id,
+						budgetType: 'reserve',
+						isDefaultReserve: true,
+					},
+					data: {
+						isDefaultReserve: false,
+					},
+				});
+			}
+
+			return await tx.category.update({
+				where: { id: category.id },
+				data: updateData,
+			});
 		});
 
 		res.status(200).json({
@@ -2307,6 +2327,7 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 			type: updated.budgetType || 'spending',
 			targetAmount: updated.targetAmount === null ? null : Number(updated.targetAmount),
 			currentAmount: updated.currentAmount === null ? null : Number(updated.currentAmount),
+			isDefaultReserve: Boolean(updated.isDefaultReserve),
 			dueDay: updated.dueDay ?? null,
 			targetDate: updated.targetDate ? updated.targetDate.toISOString() : null,
 		});

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -2277,7 +2277,12 @@ router.put('/api/budgets/:id', requireAuth, async (req: Request, res: Response) 
 		}
 
 		const normalizedBudgetType = type !== undefined ? normalizeBudgetType(type) : (category.budgetType || 'spending');
-		const normalizedIsDefaultReserve = !!isDefaultReserve && normalizedBudgetType === 'reserve';
+		if (isDefaultReserve !== undefined && typeof isDefaultReserve !== 'boolean') {
+			return res.status(400).json({ message: 'Invalid default reserve value' });
+		}
+		const normalizedIsDefaultReserve = isDefaultReserve !== undefined
+			? isDefaultReserve && normalizedBudgetType === 'reserve'
+			: (normalizedBudgetType === 'reserve' ? Boolean(category.isDefaultReserve) : false);
 		const updateData: Prisma.CategoryUpdateInput = {
 			amountLimit: limit,
 			budgetType: normalizedBudgetType,

--- a/tests/budget-routes.test.ts
+++ b/tests/budget-routes.test.ts
@@ -190,6 +190,53 @@ describe('Budget Routes', () => {
 		});
 	});
 
+	it('should preserve an existing default reserve when the update omits isDefaultReserve', async () => {
+		const category = createCategory({
+			id: 33,
+			userId: 1,
+			name: 'Emergency reserve',
+			amountLimit: new Decimal(100),
+			budgetType: 'reserve',
+			isDefaultReserve: true,
+		});
+		const updatedCategory = createCategory({
+			...category,
+			isDefaultReserve: true,
+		});
+
+		prismaMock.category.findFirst.mockResolvedValue(category);
+		prismaMock.category.update.mockResolvedValue(updatedCategory);
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback({
+					category: {
+						updateMany: jest.fn(),
+						findFirst: jest.fn().mockResolvedValue(category as never),
+						update: jest.fn().mockResolvedValue(updatedCategory as never),
+					},
+				});
+			})
+		);
+
+		const response = await request(app)
+			.put('/api/budgets/33')
+			.send({ limit: 100, type: 'reserve' });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toMatchObject({
+			id: String(updatedCategory.id),
+			category: updatedCategory.name,
+			limit: 100,
+			type: 'reserve',
+			isDefaultReserve: true,
+		});
+	});
+
 	it('should return the backend-calculated monthly budget overview for overflow routing', async () => {
 		const bills = createCategory({
 			id: 18,

--- a/tests/budget-routes.test.ts
+++ b/tests/budget-routes.test.ts
@@ -49,6 +49,21 @@ describe('Budget Routes', () => {
 
 		prismaMock.category.findFirst.mockResolvedValue(category);
 		prismaMock.category.update.mockResolvedValue(updatedCategory);
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback({
+					category: {
+						updateMany: jest.fn(),
+						update: jest.fn().mockResolvedValue(updatedCategory as never),
+					},
+				});
+			})
+		);
 
 		const response = await request(app)
 			.put('/api/budgets/10')
@@ -62,16 +77,15 @@ describe('Budget Routes', () => {
 			type: 'spending',
 			targetAmount: null,
 			currentAmount: null,
+			isDefaultReserve: false,
 			dueDay: null,
 			targetDate: null,
 		});
 		expect(prismaMock.category.findFirst).toHaveBeenCalledWith({
 			where: { id: 10, userId: 1 },
 		});
-		expect(prismaMock.category.update).toHaveBeenCalledWith({
-			where: { id: category.id },
-			data: { amountLimit: 350 },
-		});
+		expect(prismaMock.category.update).not.toHaveBeenCalled();
+		expect(prismaMock.$transaction).toHaveBeenCalled();
 	});
 
 	it('should return 404 when the budget category does not belong to the authenticated user', async () => {
@@ -127,6 +141,53 @@ describe('Budget Routes', () => {
 			data: { isCumulative: false },
 		});
 		expect(prismaMock.$executeRaw).toHaveBeenCalled();
+	});
+
+	it('should mark a reserve budget as the default reserve', async () => {
+		const category = createCategory({
+			id: 33,
+			userId: 1,
+			name: 'Emergency reserve',
+			amountLimit: new Decimal(100),
+			budgetType: 'reserve',
+			isDefaultReserve: false,
+		});
+		const updatedCategory = createCategory({
+			...category,
+			isDefaultReserve: true,
+		});
+
+		prismaMock.category.findFirst.mockResolvedValue(category);
+		prismaMock.category.update.mockResolvedValue(updatedCategory);
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback({
+					category: {
+						updateMany: jest.fn(),
+						findFirst: jest.fn().mockResolvedValue(category as never),
+						update: jest.fn().mockResolvedValue(updatedCategory as never),
+					},
+				});
+			})
+		);
+
+		const response = await request(app)
+			.put('/api/budgets/33')
+			.send({ limit: 100, type: 'reserve', isDefaultReserve: true });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toMatchObject({
+			id: String(updatedCategory.id),
+			category: updatedCategory.name,
+			limit: 100,
+			type: 'reserve',
+			isDefaultReserve: true,
+		});
 	});
 
 	it('should return the backend-calculated monthly budget overview for overflow routing', async () => {

--- a/tests/budget-routes.test.ts
+++ b/tests/budget-routes.test.ts
@@ -129,6 +129,93 @@ describe('Budget Routes', () => {
 		expect(prismaMock.$executeRaw).toHaveBeenCalled();
 	});
 
+	it('should return the backend-calculated monthly budget overview for overflow routing', async () => {
+		const bills = createCategory({
+			id: 18,
+			userId: 1,
+			name: 'Bills & Utilities',
+			amountLimit: new Decimal(750),
+		});
+		const education = createCategory({
+			id: 15,
+			userId: 1,
+			name: 'Education',
+			amountLimit: new Decimal(100),
+		});
+
+		mockGetOrCreateCurrentPeriods.mockResolvedValue(
+			new Map([
+				[18, { carryOver: new Decimal(0) }],
+				[15, { carryOver: new Decimal(0) }],
+			]) as never
+		);
+
+		prismaMock.category.findMany.mockResolvedValue([bills, education] as never);
+		prismaMock.transaction.findMany.mockResolvedValue([
+			{
+				id: 626,
+				type: 'expense',
+				amount: new Decimal(579.5),
+				categoryId: 18,
+				referenceId: null,
+			},
+			{
+				id: 625,
+				type: 'expense',
+				amount: new Decimal(144),
+				categoryId: 18,
+				referenceId: null,
+			},
+			{
+				id: 627,
+				type: 'expense',
+				amount: new Decimal(6.7),
+				categoryId: 18,
+				referenceId: null,
+			},
+			{
+				id: 658,
+				type: 'expense',
+				amount: new Decimal(1),
+				categoryId: 18,
+				referenceId: null,
+			},
+			{
+				id: 659,
+				type: 'expense',
+				amount: new Decimal(1),
+				categoryId: 18,
+				referenceId: null,
+			},
+		] as never);
+
+		const response = await request(app).get('/api/budgets/monthly-overview?month=6&year=2026');
+
+		expect(response.status).toBe(200);
+		expect(response.body.budgets).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					categoryId: 18,
+					category: 'Bills & Utilities',
+					limit: 750,
+					rawSpent: 732.2,
+					adjustedSpent: 732.2,
+					overage: 0,
+					remaining: 17.8,
+				}),
+				expect.objectContaining({
+					categoryId: 15,
+					category: 'Education',
+					limit: 100,
+					rawSpent: 0,
+					adjustedSpent: 0,
+					overage: 0,
+					remaining: 100,
+				}),
+			])
+		);
+	});
+
 	it('should save an overflow assignment and create matching transfer transactions', async () => {
 		const sourceCategory = createCategory({
 			id: 21,

--- a/tests/bulk-import-idempotency.test.ts
+++ b/tests/bulk-import-idempotency.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { prismaMock } from '../modules/database/database.module.mock';
 import { createCategory, createPaymentMethod, createTransaction } from '../prisma/factories';
 import { Decimal } from '@prisma/client/runtime/library';
+import { BaseTransactions } from '../modules/base-transactions/base-transactions.module';
 
 import app from '../app';
 
@@ -195,7 +196,28 @@ describe('Bulk Import Idempotency', () => {
 		expect(prismaMock.category.findMany).not.toHaveBeenCalled();
 	});
 
-	it('should reject bulk import when a transaction type casing is invalid', async () => {
+	it('should accept capitalized transaction types in bulk import', async () => {
+		const category = createCategory({ id: 20, userId: 1, name: 'Food' } as never);
+		const cashPaymentMethod = createPaymentMethod({ id: 21, userId: 1, name: 'Cash' } as never);
+		const createdTransaction = createTransaction({
+			id: 22,
+			userId: 1,
+			description: 'Case invalid row',
+			amount: new Decimal(20),
+			currency: 'USD',
+			type: 'income',
+			categoryId: category.id,
+			paymentMethodId: cashPaymentMethod.id,
+		} as never);
+
+		prismaMock.category.findMany.mockResolvedValue([category] as never);
+		prismaMock.paymentMethod.findMany.mockResolvedValue([cashPaymentMethod] as never);
+		prismaMock.transaction.findMany.mockResolvedValue([] as never);
+		jest.spyOn(BaseTransactions, 'safeCreateTransaction').mockResolvedValue({
+			transaction: createdTransaction,
+			isDuplicate: false,
+		} as never);
+
 		const response = await request(app)
 			.post('/api/transactions/bulk')
 			.send({
@@ -210,8 +232,12 @@ describe('Bulk Import Idempotency', () => {
 				],
 			});
 
-		expect(response.status).toBe(400);
-		expect(response.body).toEqual({ message: 'Missing or invalid required fields' });
-		expect(prismaMock.transaction.create).not.toHaveBeenCalled();
+		expect(response.status).toBe(201);
+		expect(response.body).toHaveLength(1);
+		expect(response.body[0]).toMatchObject({
+			type: 'income',
+			description: 'Case invalid row',
+		});
+		expect(BaseTransactions.safeCreateTransaction).toHaveBeenCalled();
 	});
 });

--- a/tests/category-routes.test.ts
+++ b/tests/category-routes.test.ts
@@ -37,6 +37,7 @@ describe('Category Routes', () => {
 				// eslint-disable-next-line n/no-callback-literal
 				return callback({
 					category: {
+						updateMany: jest.fn(),
 						create: jest.fn().mockResolvedValue(createdCategory as never),
 					},
 					keyword: {
@@ -55,5 +56,45 @@ describe('Category Routes', () => {
 
 		expect(response.status).toBe(201);
 		expect(response.body.icon).toBe('utensils');
+	});
+
+	it('should mark a reserve category as the default reserve', async () => {
+		const createdCategory = createCategory({
+			id: 2,
+			userId: 1,
+			name: 'Emergency reserve',
+			budgetType: 'reserve',
+			isDefaultReserve: true,
+		} as never);
+
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) =>
+			Promise.resolve().then(() => {
+				if (typeof callback !== 'function') {
+					throw new Error('Expected transaction callback');
+				}
+
+				// eslint-disable-next-line n/no-callback-literal
+				return callback({
+					category: {
+						updateMany: jest.fn(),
+						create: jest.fn().mockResolvedValue(createdCategory as never),
+					},
+					keyword: {
+						upsert: jest.fn(),
+					},
+					categoryKeyword: {
+						create: jest.fn(),
+					},
+				});
+			})
+		);
+
+		const response = await request(app)
+			.post('/api/categories')
+			.send({ name: 'Emergency reserve', budgetType: 'reserve', isDefaultReserve: true, keywords: [] });
+
+		expect(response.status).toBe(201);
+		expect(response.body.budgetType).toBe('reserve');
+		expect(response.body.isDefaultReserve).toBe(true);
 	});
 });

--- a/tests/transaction-crud.test.ts
+++ b/tests/transaction-crud.test.ts
@@ -105,7 +105,7 @@ describe('Transaction API (CRUD)', () => {
 			description: 'Lunch',
 			amount: new Decimal(14),
 			currency: 'USD',
-			type: 'debit',
+			type: 'expense',
 			categoryId: null,
 			paymentMethodId: paymentMethod.id,
 			referenceId: 'abc-123',
@@ -186,7 +186,34 @@ describe('Transaction API (CRUD)', () => {
 		expect(prismaMock.transaction.create).not.toHaveBeenCalled();
 	});
 
-	it('should reject transaction creation when type casing is invalid', async () => {
+	it('should accept capitalized transaction types', async () => {
+		const category = createCategory({ id: 60, userId: 1, name: 'Food' } as never);
+		const paymentMethod = createPaymentMethod({ id: 61, userId: 1, name: 'Cash' } as never);
+		const createdTransaction = createTransaction({
+			id: 62,
+			userId: 1,
+			description: 'Case payload',
+			amount: new Decimal(10),
+			currency: 'USD',
+			type: 'income',
+			categoryId: category.id,
+			paymentMethodId: paymentMethod.id,
+		} as never);
+
+		prismaMock.category.findFirst.mockResolvedValue(category);
+		prismaMock.paymentMethod.findFirst.mockResolvedValue(paymentMethod);
+		jest.spyOn(BaseTransactions, 'safeCreateTransaction').mockResolvedValue({
+			transaction: createdTransaction,
+			isDuplicate: false,
+		} as never);
+		prismaMock.transaction.findFirst.mockResolvedValueOnce({
+			...createdTransaction,
+			category,
+			paymentMethod,
+			cashLot: null,
+			cashLotAllocations: [],
+		} as never);
+
 		const response = await request(app).post('/api/transactions').send({
 			date: '2026-03-20',
 			description: 'Case payload',
@@ -196,9 +223,12 @@ describe('Transaction API (CRUD)', () => {
 			currency: 'USD',
 		});
 
-		expect(response.status).toBe(400);
-		expect(response.body).toEqual({ message: 'Missing or invalid required fields' });
-		expect(prismaMock.transaction.create).not.toHaveBeenCalled();
+		expect(response.status).toBe(201);
+		expect(response.body).toMatchObject({
+			type: 'income',
+			description: 'Case payload',
+		});
+		expect(BaseTransactions.safeCreateTransaction).toHaveBeenCalled();
 	});
 
 	it('should reject transaction creation when googleMapsUrl is invalid', async () => {
@@ -226,7 +256,7 @@ describe('Transaction API (CRUD)', () => {
 			description: 'Flight',
 			amount: new Decimal(120),
 			currency: 'USD',
-			type: 'debit',
+			type: 'expense',
 			paymentMethodId: paymentMethod.id,
 		} as never);
 
@@ -314,7 +344,7 @@ describe('Transaction API (CRUD)', () => {
 			description: 'Netflix subscription',
 			amount: new Decimal(15),
 			currency: 'USD',
-			type: 'debit',
+			type: 'expense',
 			paymentMethodId: paymentMethod.id,
 		} as never);
 		const keyword = createKeyword({ id: 11, userId: 1, name: 'netflix' } as never);
@@ -578,7 +608,7 @@ describe('Transaction API (CRUD)', () => {
 			amount: new Decimal(100),
 			originalCurrencyAmount: new Decimal(100),
 			currency: 'USD',
-			type: 'debit',
+			type: 'expense',
 			paymentMethodId: paymentMethod.id,
 			categoryId: category.id,
 		} as never);
@@ -668,7 +698,7 @@ describe('Transaction API (CRUD)', () => {
 			amount: new Decimal(20000),
 			originalCurrencyAmount: new Decimal(20000),
 			currency: 'ARS',
-			type: 'debit',
+			type: 'expense',
 			categoryId: category.id,
 			paymentMethodId: paymentMethod.id,
 		} as never);
@@ -761,7 +791,7 @@ describe('Transaction API (CRUD)', () => {
 			amount: new Decimal(20000),
 			originalCurrencyAmount: new Decimal(20000),
 			currency: 'ARS',
-			type: 'debit',
+			type: 'expense',
 			categoryId: 31,
 			paymentMethodId: 41,
 		} as never);
@@ -831,7 +861,7 @@ describe('Transaction API (CRUD)', () => {
 			amount: new Decimal(100),
 			originalCurrencyAmount: new Decimal(100),
 			currency: 'USD',
-			type: 'debit',
+			type: 'expense',
 			categoryId: category.id,
 			paymentMethodId: paymentMethod.id,
 		} as never);


### PR DESCRIPTION
Adds the default reserve month-end allocation flow, including:
- default reserve category flag
- monthly reserve allocation table
- cron sync to route leftover surplus
- backend tests

Also includes the release version bump to 0.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Default reserve allocations: Reserve categories marked as default now automatically sync monthly surplus to budget allocations.
  * New monthly budget overview endpoint with budget status and computed metrics (remaining balance, overage, percentage spent).
  * Budgets now display default reserve status in API responses.
  * Budget updates support designating a reserve category as the default.

* **Tests**
  * Added comprehensive test coverage for default reserve allocation functionality and monthly budget overview endpoint.
  * Updated tests for transaction type normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->