### PR TITLE
feat(transactions): rescan uncategorized by keywords

### DIFF
--- a/routes/router.ts
+++ b/routes/router.ts
@@ -297,6 +297,7 @@ type BudgetOverflowTransferTransaction = {
 	amount: Prisma.Decimal | number | null;
 	categoryId: number | null;
 	referenceId: string | null;
+	description?: string | null;
 };
 
 type BudgetOverflowState = {
@@ -386,7 +387,17 @@ async function loadMonthlyBudgetOverflowStates(
 			},
 			select: {
 				id: true,
+				name: true,
 				amountLimit: true,
+				categoryKeyword: {
+					select: {
+						keyword: {
+							select: {
+								name: true,
+							},
+						},
+					},
+				},
 			},
 		}),
 		BudgetRollover.getOrCreateCurrentPeriods(
@@ -420,19 +431,40 @@ async function loadMonthlyBudgetOverflowStates(
 				amount: true,
 				categoryId: true,
 				referenceId: true,
+				description: true,
 			},
 		}),
 	]);
 
+	const categoryById = new Map(categories.map((category) => [category.id, category] as const));
+	const categoriesForInference = categories.map((category) => ({
+		id: category.id,
+		name: category.name,
+		categoryKeyword: category.categoryKeyword ?? [],
+	}));
+
+	const inferBudgetCategoryId = (transaction: BudgetOverflowTransferTransaction): number | null => {
+		const category = transaction.categoryId == null ? null : categoryById.get(transaction.categoryId);
+		const normalizedCategoryName = category?.name.trim().toLowerCase() ?? '';
+
+		if (!category || normalizedCategoryName === 'other') {
+			const inferredCategory = pickBestKeywordCategory(transaction.description ?? null, categoriesForInference, 'other');
+			return inferredCategory?.id ?? transaction.categoryId;
+		}
+
+		return transaction.categoryId;
+	};
+
 	const transactionsByCategoryId = new Map<number, BudgetOverflowTransferTransaction[]>();
 	for (const transaction of transactions) {
-		if (transaction.categoryId == null) {
+		const resolvedCategoryId = inferBudgetCategoryId(transaction as BudgetOverflowTransferTransaction);
+		if (resolvedCategoryId == null) {
 			continue;
 		}
 
-		const next = transactionsByCategoryId.get(transaction.categoryId) ?? [];
+		const next = transactionsByCategoryId.get(resolvedCategoryId) ?? [];
 		next.push(transaction as BudgetOverflowTransferTransaction);
-		transactionsByCategoryId.set(transaction.categoryId, next);
+		transactionsByCategoryId.set(resolvedCategoryId, next);
 	}
 
 	const stateByCategoryId = new Map<number, BudgetOverflowState>();
@@ -2071,6 +2103,146 @@ router.post('/api/transactions/category-keyword/reassign', requireAuth, async (r
 	} catch (error) {
 		logger.error('Failed to reassign transactions by keyword', { error, userId: req.user.id });
 		return res.status(500).json({ message: 'Failed to reassign transactions by keyword' });
+	}
+});
+
+router.post('/api/transactions/category-keyword/rescan', requireAuth, async (req: Request, res: Response) => {
+	try {
+		const {
+			month,
+			year,
+			dryRun = true,
+			limit = 1000,
+		} = req.body as {
+			month?: number;
+			year?: number;
+			dryRun?: boolean;
+			limit?: number;
+		};
+
+		const safeLimit = Math.min(Math.max(Number(limit) || 1000, 1), 1000);
+		const normalizedMonth = Number(month);
+		const normalizedYear = Number(year);
+		let dateFilter: {
+			date?: {
+				gte: Date;
+				lt: Date;
+			};
+		} = {};
+
+		if ((month !== undefined || year !== undefined) && (!Number.isInteger(normalizedMonth) || !Number.isInteger(normalizedYear))) {
+			return res.status(400).json({ message: 'month and year must be valid integers when provided' });
+		}
+
+		if (Number.isInteger(normalizedMonth) && Number.isInteger(normalizedYear)) {
+			if (normalizedMonth < 1 || normalizedMonth > 12 || normalizedYear < 2000 || normalizedYear > 2100) {
+				return res.status(400).json({ message: 'month and year are out of range' });
+			}
+
+			dateFilter = {
+				date: {
+					gte: new Date(Date.UTC(normalizedYear, normalizedMonth - 1, 1, 0, 0, 0, 0)),
+					lt: new Date(Date.UTC(normalizedYear, normalizedMonth, 1, 0, 0, 0, 0)),
+				},
+			};
+		}
+
+		const categories = await prisma.category.findMany({
+			where: { userId: req.user.id },
+			select: {
+				id: true,
+				name: true,
+				categoryKeyword: {
+					select: {
+						keyword: {
+							select: {
+								name: true,
+							},
+						},
+					},
+				},
+			},
+		});
+
+		const candidateTransactions = await prisma.transaction.findMany({
+			where: {
+				userId: req.user.id,
+				...dateFilter,
+				OR: [
+					{ categoryId: null },
+					{
+						category: {
+							name: {
+								equals: 'Other',
+							},
+						},
+					},
+				],
+			},
+			select: {
+				id: true,
+				description: true,
+				categoryId: true,
+				reviewedAt: true,
+				category: {
+					select: {
+						name: true,
+					},
+				},
+			},
+			orderBy: {
+				reviewedAt: 'desc',
+			},
+			take: safeLimit,
+		});
+
+		const plannedChanges = candidateTransactions
+			.map((transaction) => {
+				const reassignedCategory = pickBestKeywordCategory(transaction.description ?? null, categories, 'other');
+
+				if (!reassignedCategory || reassignedCategory.id === transaction.categoryId) {
+					return null;
+				}
+
+				return {
+					id: String(transaction.id),
+					description: transaction.description ?? 'No description',
+					previousCategory: transaction.category?.name ?? null,
+					previousCategoryId: transaction.categoryId,
+					newCategory: reassignedCategory.name,
+					newCategoryId: reassignedCategory.id,
+					matchedKeyword: reassignedCategory.matchedKeyword,
+				};
+			})
+			.filter((change): change is NonNullable<typeof change> => change !== null);
+
+		if (!dryRun && plannedChanges.length > 0) {
+			await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+				for (const change of plannedChanges) {
+					await tx.transaction.update({
+						where: { id: Number(change.id) },
+						data: {
+							categoryId: change.newCategoryId,
+							reviewed: true,
+							reviewedAt: new Date(),
+						},
+					});
+				}
+			});
+		}
+
+		return res.status(200).json({
+			dryRun,
+			month: Number.isInteger(normalizedMonth) ? normalizedMonth : null,
+			year: Number.isInteger(normalizedYear) ? normalizedYear : null,
+			matchedTransactionCount: candidateTransactions.length,
+			reassignedCount: plannedChanges.length,
+			unmatchedCount: candidateTransactions.length - plannedChanges.length,
+			changes: plannedChanges,
+		});
+	} catch (error) {
+		logger.error('Failed to rescan transactions by keyword', { error, userId: req.user.id });
+		return res.status(500).json({ message: 'Failed to rescan transactions by keyword' });
 	}
 });
 

--- a/src/lib/monthly-share-summary.ts
+++ b/src/lib/monthly-share-summary.ts
@@ -56,6 +56,58 @@ function roundAmount(value: number) {
   return Math.round(value * 100) / 100;
 }
 
+function pickBestKeywordCategory(
+  description: string | null,
+  categories: {
+    id: number;
+    name: string;
+    categoryKeyword: { keyword: { name: string } }[];
+  }[],
+  excludedKeyword: string
+): { id: number; name: string; matchedKeyword: string } | null {
+  const normalizedDescription = description?.trim().toLowerCase();
+  if (!normalizedDescription) {
+    return null;
+  }
+
+  const matches = categories
+    .map((category) => {
+      const matchedKeywords = category.categoryKeyword
+        .map((entry) => entry.keyword.name.trim().toLowerCase())
+        .filter((keyword) => keyword && keyword !== excludedKeyword && normalizedDescription.includes(keyword));
+
+      if (matchedKeywords.length === 0) {
+        return null;
+      }
+
+      const longestKeyword = matchedKeywords.reduce((longest, keyword) =>
+        keyword.length > longest.length ? keyword : longest
+      );
+
+      return {
+        id: category.id,
+        name: category.name,
+        matchedKeyword: longestKeyword,
+        matchCount: matchedKeywords.length,
+        longestKeywordLength: longestKeyword.length,
+      };
+    })
+    .filter((match): match is NonNullable<typeof match> => match !== null)
+    .sort((left, right) => {
+      if (right.longestKeywordLength !== left.longestKeywordLength) {
+        return right.longestKeywordLength - left.longestKeywordLength;
+      }
+
+      if (right.matchCount !== left.matchCount) {
+        return right.matchCount - left.matchCount;
+      }
+
+      return left.name.localeCompare(right.name);
+    });
+
+  return matches[0] ?? null;
+}
+
 export function createShareToken() {
   return crypto.randomBytes(24).toString('hex');
 }
@@ -85,6 +137,20 @@ export async function buildSharedMonthlySummary(userId: number, month: number, y
     }),
     prisma.category.findMany({
       where: { userId },
+      select: {
+        id: true,
+        name: true,
+        amountLimit: true,
+        categoryKeyword: {
+          select: {
+            keyword: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
       orderBy: { name: 'asc' },
     }),
   ]);
@@ -103,6 +169,11 @@ export async function buildSharedMonthlySummary(userId: number, month: number, y
   const net = roundAmount(income - expenses);
 
   const budgetCategories = categories.filter((category) => Number(category.amountLimit ?? 0) > 0);
+  const categoriesForInference = budgetCategories.map((category) => ({
+    id: category.id,
+    name: category.name,
+    categoryKeyword: category.categoryKeyword ?? [],
+  }));
   const budgetPeriods = await BudgetRollover.getOrCreateCurrentPeriods(
     budgetCategories.map((category) => category.id),
     startDate
@@ -112,7 +183,19 @@ export async function buildSharedMonthlySummary(userId: number, month: number, y
     .map((category) => {
       const spent = roundAmount(
         transactions
-          .filter((transaction) => transaction.categoryId === category.id)
+          .filter((transaction) => {
+            if (transaction.categoryId === category.id) {
+              return true;
+            }
+
+            const transactionCategoryName = transaction.category?.name?.trim().toLowerCase() ?? '';
+            if (transactionCategoryName && transactionCategoryName !== 'other') {
+              return false;
+            }
+
+            const inferredCategory = pickBestKeywordCategory(transaction.description ?? null, categoriesForInference, 'other');
+            return inferredCategory?.id === category.id;
+          })
           .reduce((sum, transaction) => {
             const amount = Number(transaction.amount ?? 0);
             const isTransfer = isBudgetOverflowTransferTransaction(transaction.referenceId);
@@ -153,7 +236,11 @@ export async function buildSharedMonthlySummary(userId: number, month: number, y
   const spendingByCategory = new Map<string, number>();
   for (const transaction of visibleTransactions) {
     if (transaction.type !== 'expense') continue;
-    const categoryName = transaction.category?.name ?? 'Other';
+    const normalizedTransactionCategoryName = transaction.category?.name?.trim().toLowerCase() ?? '';
+    const categoryName =
+      !normalizedTransactionCategoryName || normalizedTransactionCategoryName === 'other'
+        ? pickBestKeywordCategory(transaction.description ?? null, categoriesForInference, 'other')?.name ?? 'Other'
+        : transaction.category?.name ?? 'Other';
     spendingByCategory.set(categoryName, roundAmount((spendingByCategory.get(categoryName) ?? 0) + Number(transaction.amount ?? 0)));
   }
 

--- a/tests/budget-routes.test.ts
+++ b/tests/budget-routes.test.ts
@@ -250,15 +250,39 @@ describe('Budget Routes', () => {
 			name: 'Education',
 			amountLimit: new Decimal(100),
 		});
+		const transportation = createCategory({
+			id: 19,
+			userId: 1,
+			name: 'Transportation',
+			amountLimit: new Decimal(150),
+		});
 
 		mockGetOrCreateCurrentPeriods.mockResolvedValue(
 			new Map([
 				[18, { carryOver: new Decimal(0) }],
 				[15, { carryOver: new Decimal(0) }],
+				[19, { carryOver: new Decimal(0) }],
 			]) as never
 		);
 
-		prismaMock.category.findMany.mockResolvedValue([bills, education] as never);
+		prismaMock.category.findMany.mockResolvedValue([
+			{
+				...bills,
+				categoryKeyword: [],
+			},
+			{
+				...education,
+				categoryKeyword: [],
+			},
+			{
+				...transportation,
+				categoryKeyword: [
+					{
+						keyword: { name: 'uber' },
+					},
+				],
+			},
+		] as never);
 		prismaMock.transaction.findMany.mockResolvedValue([
 			{
 				id: 626,
@@ -266,6 +290,7 @@ describe('Budget Routes', () => {
 				amount: new Decimal(579.5),
 				categoryId: 18,
 				referenceId: null,
+				description: 'Bill payment',
 			},
 			{
 				id: 625,
@@ -273,6 +298,7 @@ describe('Budget Routes', () => {
 				amount: new Decimal(144),
 				categoryId: 18,
 				referenceId: null,
+				description: 'Another bill',
 			},
 			{
 				id: 627,
@@ -280,6 +306,7 @@ describe('Budget Routes', () => {
 				amount: new Decimal(6.7),
 				categoryId: 18,
 				referenceId: null,
+				description: 'Utility charge',
 			},
 			{
 				id: 658,
@@ -287,6 +314,7 @@ describe('Budget Routes', () => {
 				amount: new Decimal(1),
 				categoryId: 18,
 				referenceId: null,
+				description: 'Small fee',
 			},
 			{
 				id: 659,
@@ -294,6 +322,15 @@ describe('Budget Routes', () => {
 				amount: new Decimal(1),
 				categoryId: 18,
 				referenceId: null,
+				description: 'Small fee',
+			},
+			{
+				id: 660,
+				type: 'expense',
+				amount: new Decimal(50),
+				categoryId: null,
+				referenceId: null,
+				description: 'Uber to work',
 			},
 		] as never);
 
@@ -317,6 +354,15 @@ describe('Budget Routes', () => {
 					limit: 100,
 					rawSpent: 0,
 					adjustedSpent: 0,
+					overage: 0,
+					remaining: 100,
+				}),
+				expect.objectContaining({
+					categoryId: 19,
+					category: 'Transportation',
+					limit: 150,
+					rawSpent: 50,
+					adjustedSpent: 50,
 					overage: 0,
 					remaining: 100,
 				}),

--- a/tests/monthly-share-summary.test.ts
+++ b/tests/monthly-share-summary.test.ts
@@ -1,0 +1,144 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { prismaMock } from '../modules/database/database.module.mock';
+import { BudgetRollover } from '../modules/budgets/budget-rollover.service';
+import { buildSharedMonthlySummary } from '../src/lib/monthly-share-summary';
+
+jest.mock('../modules/budgets/budget-rollover.service', () => ({
+	BudgetRollover: {
+		getOrCreateCurrentPeriods: jest.fn(),
+	},
+}));
+
+const mockGetOrCreateCurrentPeriods = BudgetRollover.getOrCreateCurrentPeriods as jest.Mock;
+
+describe('buildSharedMonthlySummary', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('counts keyword-matched transportation expenses in monthly budget metrics', async () => {
+		prismaMock.transaction.findMany.mockResolvedValue([
+			{
+				id: 626,
+				type: 'expense',
+				amount: new Decimal(579.5),
+				categoryId: 18,
+				referenceId: null,
+				description: 'Bill payment',
+				category: { id: 18, name: 'Bills & Utilities' },
+			},
+			{
+				id: 625,
+				type: 'expense',
+				amount: new Decimal(144),
+				categoryId: 18,
+				referenceId: null,
+				description: 'Another bill',
+				category: { id: 18, name: 'Bills & Utilities' },
+			},
+			{
+				id: 627,
+				type: 'expense',
+				amount: new Decimal(6.7),
+				categoryId: 18,
+				referenceId: null,
+				description: 'Utility charge',
+				category: { id: 18, name: 'Bills & Utilities' },
+			},
+			{
+				id: 658,
+				type: 'expense',
+				amount: new Decimal(1),
+				categoryId: 18,
+				referenceId: null,
+				description: 'Small fee',
+				category: { id: 18, name: 'Bills & Utilities' },
+			},
+			{
+				id: 659,
+				type: 'expense',
+				amount: new Decimal(1),
+				categoryId: 18,
+				referenceId: null,
+				description: 'Small fee',
+				category: { id: 18, name: 'Bills & Utilities' },
+			},
+			{
+				id: 660,
+				type: 'expense',
+				amount: new Decimal(50),
+				categoryId: null,
+				referenceId: null,
+				description: 'Uber to work',
+				category: null,
+			},
+		] as never);
+
+		prismaMock.category.findMany.mockResolvedValue([
+			{
+				id: 15,
+				name: 'Education',
+				amountLimit: new Decimal(100),
+				categoryKeyword: [],
+			},
+			{
+				id: 18,
+				name: 'Bills & Utilities',
+				amountLimit: new Decimal(750),
+				categoryKeyword: [],
+			},
+			{
+				id: 19,
+				name: 'Transportation',
+				amountLimit: new Decimal(150),
+				categoryKeyword: [
+					{
+						keyword: { name: 'uber' },
+					},
+				],
+			},
+		] as never);
+
+		mockGetOrCreateCurrentPeriods.mockResolvedValue(
+			new Map([
+				[15, { carryOver: new Decimal(0) }],
+				[18, { carryOver: new Decimal(0) }],
+				[19, { carryOver: new Decimal(0) }],
+			]) as never
+		);
+
+		const summary = await buildSharedMonthlySummary(1, 6, 2026, 'token', 'June summary', new Date('2026-06-30T00:00:00Z'), null);
+
+		expect(summary.budgets).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					categoryId: 18,
+					category: 'Bills & Utilities',
+					limit: 750,
+					spent: 732.2,
+					remaining: 17.8,
+				}),
+				expect.objectContaining({
+					categoryId: 19,
+					category: 'Transportation',
+					limit: 150,
+					spent: 50,
+					remaining: 100,
+				}),
+			])
+		);
+		expect(summary.topCategories).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					category: 'Bills & Utilities',
+					amount: 732.2,
+				}),
+				expect.objectContaining({
+					category: 'Transportation',
+					amount: 50,
+				}),
+			])
+		);
+	});
+});

--- a/tests/transaction-crud.test.ts
+++ b/tests/transaction-crud.test.ts
@@ -579,6 +579,136 @@ describe('Transaction API (CRUD)', () => {
 		expect(prismaMock.keyword.findFirst).not.toHaveBeenCalled();
 	});
 
+	it('should rescan only uncategorized or other transactions and reassign by keywords', async () => {
+		const otherCategory = createCategory({ id: 13, userId: 1, name: 'Other' } as never);
+		const transportationCategory = createCategory({ id: 14, userId: 1, name: 'Transportation' } as never);
+
+		prismaMock.category.findMany.mockResolvedValue([
+			{
+				...otherCategory,
+				categoryKeyword: [],
+			},
+			{
+				...transportationCategory,
+				categoryKeyword: [{ keyword: { name: 'uber' } }],
+			},
+		] as never);
+		prismaMock.transaction.findMany.mockResolvedValue([
+			{
+				id: 201,
+				description: 'Uber to work',
+				categoryId: null,
+				category: null,
+				reviewedAt: null,
+			},
+			{
+				id: 202,
+				description: 'No keyword transaction',
+				categoryId: otherCategory.id,
+				category: { name: 'Other' },
+				reviewedAt: new Date('2026-06-05T10:00:00.000Z'),
+			},
+		] as never);
+
+		const response = await request(app)
+			.post('/api/transactions/category-keyword/rescan')
+			.send({ dryRun: true, limit: 50 });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toMatchObject({
+			dryRun: true,
+			matchedTransactionCount: 2,
+			reassignedCount: 1,
+			unmatchedCount: 1,
+		});
+		expect(response.body.changes).toEqual([
+			expect.objectContaining({
+				id: '201',
+				previousCategory: null,
+				newCategory: 'Transportation',
+				newCategoryId: transportationCategory.id,
+				matchedKeyword: 'uber',
+			}),
+		]);
+		expect(prismaMock.transaction.update).not.toHaveBeenCalled();
+	});
+
+	it('should apply keyword rescan without modifying already assigned non-other transactions', async () => {
+		const otherCategory = createCategory({ id: 13, userId: 1, name: 'Other' } as never);
+		const transportationCategory = createCategory({ id: 14, userId: 1, name: 'Transportation' } as never);
+		const foodCategory = createCategory({ id: 15, userId: 1, name: 'Food' } as never);
+		const tx = {
+			transaction: {
+				update: jest.fn().mockResolvedValue({} as never),
+			},
+		};
+
+		prismaMock.category.findMany.mockResolvedValue([
+			{
+				...otherCategory,
+				categoryKeyword: [],
+			},
+			{
+				...transportationCategory,
+				categoryKeyword: [{ keyword: { name: 'uber' } }],
+			},
+			{
+				...foodCategory,
+				categoryKeyword: [{ keyword: { name: 'coffee' } }],
+			},
+		] as never);
+		prismaMock.transaction.findMany.mockResolvedValue([
+			{
+				id: 201,
+				description: 'Uber to work',
+				categoryId: null,
+				category: null,
+				reviewedAt: null,
+			},
+			{
+				id: 202,
+				description: 'No keyword transaction',
+				categoryId: otherCategory.id,
+				category: { name: 'Other' },
+				reviewedAt: new Date('2026-06-05T10:00:00.000Z'),
+			},
+		] as never);
+		prismaMock.$transaction.mockImplementation(async (callback: unknown) => {
+			if (typeof callback !== 'function') {
+				throw new Error('Expected transaction callback');
+			}
+
+			// eslint-disable-next-line n/no-callback-literal
+			return callback(tx as never);
+		});
+
+		const response = await request(app)
+			.post('/api/transactions/category-keyword/rescan')
+			.send({ dryRun: false, limit: 50 });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toMatchObject({
+			dryRun: false,
+			matchedTransactionCount: 2,
+			reassignedCount: 1,
+			unmatchedCount: 1,
+		});
+		expect(tx.transaction.update).toHaveBeenCalledWith({
+			where: { id: 201 },
+			data: {
+				categoryId: transportationCategory.id,
+				reviewed: true,
+				reviewedAt: expect.any(Date),
+			},
+		});
+		expect(tx.transaction.update).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: 202 },
+			})
+		);
+		expect(prismaMock.transaction.update).not.toHaveBeenCalled();
+	});
+
 	it('should reject transaction updates when locationName is too long', async () => {
 		const response = await request(app)
 			.patch('/api/transactions/22')


### PR DESCRIPTION
Adds backend support for keyword-based rescanning of uncategorized transactions and improves keyword inference in budget/share summaries.

Checks:
- npm run lint ✅
- npm run test ✅
- npm run build ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic transaction recategorization using keyword matching for uncategorized or misclassified transactions.
  * Added new endpoint to rescan and reassign transactions to appropriate categories.

* **Improvements**
  * Enhanced budget overflow detection with intelligent keyword-based category inference.
  * Improved monthly budget summaries to accurately reflect inferred transaction categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->