### PR TITLE
fix(exchange-rates): use ars list endpoint and document cash income lots

### DIFF
--- a/modules/crons/task-queue.cron.ts
+++ b/modules/crons/task-queue.cron.ts
@@ -16,7 +16,7 @@ import { redisClient } from '../../src/lib/redis';
 import { cleanupOldReceiptProcessingImages } from '../../src/lib/receipt-image-storage';
 import { ReceiptOcrQueueService } from '../ai-assistant/receipt-ocr-queue.service';
 import { processReceiptOcrJob } from '../ai-assistant/receipt-ocr-job-processor.service';
-import { fetchAndStoreArsUsdRateByDate } from '../../src/helpers/rate.helper';
+import { getArsUsdRateByDate } from '../../src/helpers/rate.helper';
 import { DefaultReserve } from '../budgets/default-reserve.service';
 
 const CRON_EXPRESSIONS = {
@@ -220,7 +220,15 @@ export class TaskQueueModule {
 	private async _syncArsUsdRate() {
 		await this.withCronLock('syncArsUsdRate', 900, async () => {
 			try {
-				const storedRate = await fetchAndStoreArsUsdRateByDate(new Date(), config.ARS_USD_EXCHANGE_HOUSE);
+				const storedRate = await getArsUsdRateByDate(new Date(), config.ARS_USD_EXCHANGE_HOUSE);
+
+				if (!storedRate) {
+					logger.warn('No ARS/USD historical rate found to sync', {
+						house: config.ARS_USD_EXCHANGE_HOUSE,
+					});
+					return;
+				}
+
 				logger.info('ARS/USD historical rate synced', {
 					house: config.ARS_USD_EXCHANGE_HOUSE,
 					date: dayjs(storedRate.rateDate).format('YYYY-MM-DD'),

--- a/routes/README.md
+++ b/routes/README.md
@@ -25,6 +25,7 @@
 ## Important Notes/Gotchas
 - **Implicit Currency Conversion:** POST `/api/transactions` automatically converts VES amounts to USD using the latest available exchange rate if not already provided.
 - **Strict Type Validation:** Transaction creation endpoints reject invalid `type` values with `400 Bad Request` instead of coercing unknown values into expenses. Accepted external values are `income` and `expense`.
+- **Cash Income Lots:** Creating a manual `income` transaction with the payment method set to `Cash` automatically creates a cash lot, so incoming cash can be added manually and later consumed by cash expenses.
 - **Categorize Missing Transactions:** `PATCH /api/transactions/:id/categorize` now returns `404 Not Found` when the transaction does not exist or does not belong to the authenticated user, instead of failing with a generic `500`.
 - **Backward Compatibility:** Some endpoints (like `/api/categories/keywords`) are kept for compatibility with older frontend versions.
 - **Global Error Handling:** While most routes have local error handling, unhandled exceptions are generally caught by the main Express app wrapper.

--- a/src/helpers/rate.helper.test.ts
+++ b/src/helpers/rate.helper.test.ts
@@ -130,13 +130,10 @@ describe('historical ARS/USD rates', () => {
 
 	it('should fetch and persist the ARS/USD historical rate from ArgentinaDatos', async () => {
 		mockedAxios.get.mockResolvedValueOnce({
-			data: {
-				moneda: 'USD',
-				casa: 'blue',
-				fecha: '2026-06-09',
-				compra: 1100,
-				venta: 1125,
-			},
+			data: [
+				{ moneda: 'USD', casa: 'blue', fecha: '2026-06-08', compra: 1090, venta: 1110 },
+				{ moneda: 'USD', casa: 'blue', fecha: '2026-06-09', compra: 1100, venta: 1125 },
+			],
 		} as any);
 		prismaMock.historicalExchangeRate.upsert.mockResolvedValue({
 			id: 10,
@@ -154,7 +151,7 @@ describe('historical ARS/USD rates', () => {
 		const result = await fetchAndStoreArsUsdRateByDate('2026-06-09', 'blue');
 
 		expect(mockedAxios.get).toHaveBeenCalledWith(
-			expect.stringContaining('/v1/cotizaciones/dolares/blue/2026/06/09'),
+			expect.stringContaining('/v1/cotizaciones/dolares/blue'),
 			expect.objectContaining({ timeout: 5000 })
 		);
 		expect(prismaMock.historicalExchangeRate.upsert).toHaveBeenCalledTimes(1);
@@ -164,17 +161,12 @@ describe('historical ARS/USD rates', () => {
 	it('should fall back to previous days when the requested historical ARS/USD date is unavailable', async () => {
 		mockRedisClient.get.mockResolvedValue(null);
 		prismaMock.historicalExchangeRate.findFirst.mockResolvedValue(null);
-		mockedAxios.get
-			.mockRejectedValueOnce({ response: { status: 404 } } as any)
-			.mockResolvedValueOnce({
-				data: {
-					moneda: 'USD',
-					casa: 'blue',
-					fecha: '2026-06-08',
-					compra: 1000,
-					venta: 1050,
-				},
-			} as any);
+		mockedAxios.get.mockResolvedValueOnce({
+			data: [
+				{ moneda: 'USD', casa: 'blue', fecha: '2026-06-07', compra: 900, venta: 950 },
+				{ moneda: 'USD', casa: 'blue', fecha: '2026-06-08', compra: 1000, venta: 1050 },
+			],
+		} as any);
 		prismaMock.historicalExchangeRate.upsert.mockResolvedValue({
 			id: 11,
 			baseCurrency: 'USD',
@@ -190,7 +182,7 @@ describe('historical ARS/USD rates', () => {
 
 		const result = await getArsUsdRateByDate('2026-06-09', 'blue');
 
-		expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+		expect(mockedAxios.get).toHaveBeenCalledTimes(1);
 		expect(Number(result?.sellPrice)).toBe(1050);
 	});
 });

--- a/src/helpers/rate.helper.ts
+++ b/src/helpers/rate.helper.ts
@@ -32,6 +32,12 @@ function normalizeCalendarDate(date?: string | Date): dayjs.Dayjs {
 	return dayjs(date ?? new Date()).startOf('day');
 }
 
+function parseQuoteDate(value: string): dayjs.Dayjs | null {
+	const parsed = dayjs(value);
+
+	return parsed.isValid() ? parsed.startOf('day') : null;
+}
+
 export function normalizeArsUsdExchangeHouse(value?: string): string {
 	const normalized = value?.trim().toLowerCase() || 'blue';
 	return VALID_ARGENTINA_DOLLAR_HOUSES.has(normalized) ? normalized : 'blue';
@@ -124,21 +130,52 @@ async function persistHistoricalExchangeRate(args: {
 	return storedRate;
 }
 
+async function fetchArgentinaDatosDollarQuotes(house: string) {
+	const response = await axios.get<ArgentinaDatosHistoricalDollarQuote[]>(
+		`${config.ARGENTINA_DATOS_API_URL}/v1/cotizaciones/dolares/${house}`,
+		{
+			timeout: 5000,
+		}
+	);
+
+	return Array.isArray(response.data) ? response.data : [];
+}
+
+function findBestQuoteForDate(
+	quotes: ArgentinaDatosHistoricalDollarQuote[],
+	requestedDate: dayjs.Dayjs
+): ArgentinaDatosHistoricalDollarQuote | null {
+	let bestQuote: ArgentinaDatosHistoricalDollarQuote | null = null;
+	let bestQuoteDate: dayjs.Dayjs | null = null;
+
+	for (const quote of quotes) {
+		const quoteDate = parseQuoteDate(quote.fecha);
+		if (!quoteDate || quoteDate.isAfter(requestedDate)) {
+			continue;
+		}
+
+		if (!bestQuoteDate || quoteDate.isAfter(bestQuoteDate)) {
+			bestQuote = quote;
+			bestQuoteDate = quoteDate;
+		}
+	}
+
+	return bestQuote;
+}
+
 export async function fetchAndStoreArsUsdRateByDate(date?: string | Date, preferredHouse?: string) {
 	const normalizedDate = normalizeCalendarDate(date);
 	const house = normalizeArsUsdExchangeHouse(preferredHouse ?? config.ARS_USD_EXCHANGE_HOUSE);
-	const requestDate = normalizedDate.format('YYYY/MM/DD');
 
 	try {
-		const response = await axios.get<ArgentinaDatosHistoricalDollarQuote>(
-			`${config.ARGENTINA_DATOS_API_URL}/v1/cotizaciones/dolares/${house}/${requestDate}`,
-			{
-				timeout: 5000,
-			}
-		);
+		const quotes = await fetchArgentinaDatosDollarQuotes(house);
+		const quote = findBestQuoteForDate(quotes, normalizedDate);
 
-		const quote = response.data;
-		const quoteDate = normalizeCalendarDate(quote.fecha);
+		if (!quote) {
+			throw new Error(`No ARS/USD quote found for ${normalizedDate.format('YYYY-MM-DD')}`);
+		}
+
+		const quoteDate = parseQuoteDate(quote.fecha) ?? normalizedDate;
 
 		return persistHistoricalExchangeRate({
 			quoteCurrency: ARS_QUOTE_CURRENCY,
@@ -151,7 +188,7 @@ export async function fetchAndStoreArsUsdRateByDate(date?: string | Date, prefer
 	} catch (error) {
 		logger.warn('Failed to fetch ARS/USD historical rate from ArgentinaDatos', {
 			error,
-			requestDate,
+			requestDate: normalizedDate.format('YYYY-MM-DD'),
 			house,
 		});
 		throw error;


### PR DESCRIPTION
## Summary\n- Fix ARS/USD sync to fetch ArgentinaDatos from the list endpoint and select the best quote on or before the requested date.\n- Document that a manual income transaction with payment method Cash automatically creates a cash lot.\n\n## Verification\n- npx jest src/helpers/rate.helper.test.ts --runInBand\n- npx eslint modules/crons/task-queue.cron.ts src/helpers/rate.helper.ts src/helpers/rate.helper.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ARS/USD rate syncing to better handle missing historical rates and avoid creating invalid sync records.
  * Rate selection now uses the best available quote for the requested day, reducing failures when exact-day data is unavailable.
  * Updated cash transaction behavior so manual income entries paid in cash automatically create a matching cash lot.

* **Documentation**
  * Added a note about the new automatic cash lot behavior for manual cash income transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->