### PR TITLE
fix(balance): keep current balance separate

### DIFF
--- a/prisma/migrations/20260723090000_add_current_balance_override/migration.sql
+++ b/prisma/migrations/20260723090000_add_current_balance_override/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `User`
+    ADD COLUMN `currentBalance` DECIMAL(14, 2) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   aiSettings              AISettings?
 	dashboardBudgetPreferences Json?
 	balanceTrackingEnabled   Boolean                   @default(true)
+	currentBalance           Decimal?                  @db.Decimal(14, 2)
   categories              Category[]
   keywords                Keyword[]
   notificationLogs        NotificationLog[]

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -3225,10 +3225,13 @@ router.get('/api/settings/balance-tracking', requireAuth, async (req: Request, r
 	try {
 		const user = await prisma.user.findUnique({
 			where: { id: req.user.id },
-			select: { balanceTrackingEnabled: true },
+			select: { balanceTrackingEnabled: true, currentBalance: true },
 		});
 
-		res.status(200).json({ enabled: user?.balanceTrackingEnabled ?? true });
+		res.status(200).json({
+			enabled: user?.balanceTrackingEnabled ?? true,
+			currentBalance: user?.currentBalance === null || user?.currentBalance === undefined ? null : Number(user.currentBalance),
+		});
 	} catch (error) {
 		logger.error('Failed to fetch balance tracking settings', { error, userId: req.user.id });
 		res.status(500).json({ message: 'Failed to fetch balance tracking settings' });
@@ -3237,18 +3240,33 @@ router.get('/api/settings/balance-tracking', requireAuth, async (req: Request, r
 
 router.put('/api/settings/balance-tracking', requireAuth, async (req: Request, res: Response) => {
 	try {
-		const { enabled } = req.body as { enabled?: boolean };
-		if (typeof enabled !== 'boolean') {
+		const { enabled, currentBalance } = req.body as { enabled?: boolean; currentBalance?: number };
+		const hasEnabled = enabled !== undefined;
+		const hasCurrentBalance = currentBalance !== undefined;
+		if (!hasEnabled && !hasCurrentBalance) {
+			return res.status(400).json({ message: 'At least one balance tracking setting is required' });
+		}
+		if (hasEnabled && typeof enabled !== 'boolean') {
 			return res.status(400).json({ message: 'The enabled setting must be a boolean' });
 		}
+		if (hasCurrentBalance && (typeof currentBalance !== 'number' || !Number.isFinite(currentBalance) || currentBalance < 0)) {
+			return res.status(400).json({ message: 'The current balance must be a non-negative number' });
+		}
+
+		const data: Prisma.UserUpdateInput = {};
+		if (hasEnabled) data.balanceTrackingEnabled = enabled;
+		if (hasCurrentBalance) data.currentBalance = currentBalance;
 
 		const user = await prisma.user.update({
 			where: { id: req.user.id },
-			data: { balanceTrackingEnabled: enabled },
-			select: { balanceTrackingEnabled: true },
+			data,
+			select: { balanceTrackingEnabled: true, currentBalance: true },
 		});
 
-		res.status(200).json({ enabled: user.balanceTrackingEnabled });
+		res.status(200).json({
+			enabled: user.balanceTrackingEnabled,
+			currentBalance: user.currentBalance === null ? null : Number(user.currentBalance),
+		});
 	} catch (error) {
 		logger.error('Failed to update balance tracking settings', { error, userId: req.user.id });
 		res.status(500).json({ message: 'Failed to update balance tracking settings' });

--- a/tests/balance-tracking-settings-routes.test.ts
+++ b/tests/balance-tracking-settings-routes.test.ts
@@ -25,35 +25,51 @@ describe('Balance Tracking Settings Routes', () => {
 		const response = await request(app).get('/api/settings/balance-tracking');
 
 		expect(response.status).toBe(200);
-		expect(response.body).toEqual({ enabled: true });
+		expect(response.body).toEqual({ enabled: true, currentBalance: null });
 	});
 
 	it('returns the persisted balance tracking value', async () => {
-		prismaMock.user.findUnique.mockResolvedValue({ balanceTrackingEnabled: false } as never);
+		prismaMock.user.findUnique.mockResolvedValue({ balanceTrackingEnabled: false, currentBalance: 1250 } as never);
 
 		const response = await request(app).get('/api/settings/balance-tracking');
 
 		expect(response.status).toBe(200);
-		expect(response.body).toEqual({ enabled: false });
+		expect(response.body).toEqual({ enabled: false, currentBalance: 1250 });
 		expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
 			where: { id: 1 },
-			select: { balanceTrackingEnabled: true },
+			select: { balanceTrackingEnabled: true, currentBalance: true },
 		});
 	});
 
 	it('updates balance tracking with a validated boolean value', async () => {
-		prismaMock.user.update.mockResolvedValue({ balanceTrackingEnabled: false } as never);
+		prismaMock.user.update.mockResolvedValue({ balanceTrackingEnabled: false, currentBalance: null } as never);
 
 		const response = await request(app)
 			.put('/api/settings/balance-tracking')
 			.send({ enabled: false });
 
 		expect(response.status).toBe(200);
-		expect(response.body).toEqual({ enabled: false });
+		expect(response.body).toEqual({ enabled: false, currentBalance: null });
 		expect(prismaMock.user.update).toHaveBeenCalledWith({
 			where: { id: 1 },
 			data: { balanceTrackingEnabled: false },
-			select: { balanceTrackingEnabled: true },
+			select: { balanceTrackingEnabled: true, currentBalance: true },
+		});
+	});
+
+	it('updates the current balance without creating a transaction adjustment', async () => {
+		prismaMock.user.update.mockResolvedValue({ balanceTrackingEnabled: true, currentBalance: 500 } as never);
+
+		const response = await request(app)
+			.put('/api/settings/balance-tracking')
+			.send({ currentBalance: 500 });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ enabled: true, currentBalance: 500 });
+		expect(prismaMock.user.update).toHaveBeenCalledWith({
+			where: { id: 1 },
+			data: { currentBalance: 500 },
+			select: { balanceTrackingEnabled: true, currentBalance: true },
 		});
 	});
 


### PR DESCRIPTION
## Summary
- persist a current balance override separately from transactions
- make balance updates leave income and expense totals unchanged
- add current balance API and regression coverage

## Verification
- npx prisma generate
- npx tsc --noEmit
- balance settings tests: 5 passed