### PR TITLE
fix(balance): remove legacy adjustment movements

### DIFF
--- a/prisma/migrations/20260723100000_remove_manual_balance_adjustment_transactions/migration.sql
+++ b/prisma/migrations/20260723100000_remove_manual_balance_adjustment_transactions/migration.sql
@@ -1,0 +1,25 @@
+CREATE TEMPORARY TABLE `manual_balance_adjustment_ids` (
+  `id` INT NOT NULL PRIMARY KEY
+);
+
+INSERT INTO `manual_balance_adjustment_ids` (`id`)
+SELECT `id`
+FROM `Transaction`
+WHERE `description` LIKE 'Manual balance adjustment to $%';
+
+DELETE `allocation`
+FROM `CashLotAllocation` AS `allocation`
+INNER JOIN `manual_balance_adjustment_ids` AS `ids`
+  ON `ids`.`id` = `allocation`.`expenseTransactionId`;
+
+DELETE `lot`
+FROM `CashLot` AS `lot`
+INNER JOIN `manual_balance_adjustment_ids` AS `ids`
+  ON `ids`.`id` = `lot`.`withdrawalTransactionId`;
+
+DELETE `transaction`
+FROM `Transaction` AS `transaction`
+INNER JOIN `manual_balance_adjustment_ids` AS `ids`
+  ON `ids`.`id` = `transaction`.`id`;
+
+DROP TEMPORARY TABLE `manual_balance_adjustment_ids`;

--- a/routes/router.ts
+++ b/routes/router.ts
@@ -1202,7 +1202,6 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			cashWithdrawalDestinationAmount,
 			cashWithdrawalDestinationCurrency,
 			cashWithdrawalExchangeRate,
-			isBalanceAdjustment,
 		} = req.body as {
 			date?: string;
 			description?: string;
@@ -1221,7 +1220,6 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 			cashWithdrawalDestinationAmount?: number;
 			cashWithdrawalDestinationCurrency?: string;
 			cashWithdrawalExchangeRate?: number;
-			isBalanceAdjustment?: boolean;
 		};
 
 
@@ -1393,7 +1391,7 @@ router.post('/api/transactions', requireAuth, async (req: Request, res: Response
 					tx
 				);
 			} else {
-				if (balanceTrackingEnabled && normalizedType === 'expense' && resolvedPaymentMethod?.name === 'Cash' && !isBalanceAdjustment) {
+				if (balanceTrackingEnabled && normalizedType === 'expense' && resolvedPaymentMethod?.name === 'Cash') {
 					await CashLotServiceInstance.allocateCashExpense(transaction, tx);
 				}
 			}

--- a/tests/transaction-crud.test.ts
+++ b/tests/transaction-crud.test.ts
@@ -999,50 +999,6 @@ describe('Transaction API (CRUD)', () => {
 		});
 	});
 
-	it('should allow manual balance adjustments below the current cash balance', async () => {
-		const category = createCategory({ id: 31, userId: 1, name: 'Other' } as never);
-		const paymentMethod = createPaymentMethod({ id: 41, userId: 1, name: 'Cash' } as never);
-		const adjustmentTransaction = createTransaction({
-			id: 304,
-			userId: 1,
-			description: 'Manual balance adjustment to $3,990.91',
-			amount: new Decimal(3990.91),
-			originalCurrencyAmount: new Decimal(3990.91),
-			currency: 'USD',
-			type: 'expense',
-			categoryId: category.id,
-			paymentMethodId: paymentMethod.id,
-		} as never);
-
-		prismaMock.category.findFirst.mockResolvedValue(category);
-		prismaMock.paymentMethod.findFirst.mockResolvedValue(paymentMethod);
-		jest.spyOn(BaseTransactions, 'safeCreateTransaction').mockResolvedValue({
-			transaction: adjustmentTransaction,
-			isDuplicate: false,
-		} as never);
-		prismaMock.transaction.findFirst.mockResolvedValueOnce({
-			...adjustmentTransaction,
-			category,
-			paymentMethod,
-			cashLot: null,
-			cashLotAllocations: [],
-		} as never);
-
-		const response = await request(app).post('/api/transactions').send({
-			date: '2026-04-02',
-			description: adjustmentTransaction.description,
-			amount: 3990.91,
-			category: 'Other',
-			type: 'expense',
-			paymentMethodId: paymentMethod.id,
-			currency: 'USD',
-			isBalanceAdjustment: true,
-		});
-
-		expect(response.status).toBe(201);
-		expect(cashLotServiceMock.allocateCashExpense).not.toHaveBeenCalled();
-	});
-
 	it('should restore cash lots when deleting a cash expense', async () => {
 		const cashExpense = createTransaction({
 			id: 303,


### PR DESCRIPTION
## Summary
- remove the legacy balance-adjustment transaction bypass
- delete historical manual balance adjustment transactions and dependent cash movements via Prisma migration
- keep manual balance changes isolated from income and expense transactions

## Verification
- npx tsc --noEmit
- targeted balance-tracking Jest tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete manual balance adjustment transactions and their associated cash allocation records.
  * Improved cash withdrawal and expense processing by consistently handling destination amount, currency, and exchange rate details.
  * Updated cash-lot allocation behavior for balance-tracked cash expenses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->